### PR TITLE
Update JUnit to 4.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/src/test/java/com/pngencoder/PngEncoderBufferedImageConverterTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderBufferedImageConverterTest.java
@@ -6,7 +6,7 @@ import java.awt.image.BufferedImage;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PngEncoderBufferedImageConverterTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderBufferedImageTypeTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderBufferedImageTypeTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import java.awt.image.BufferedImage;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PngEncoderBufferedImageTypeTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderDeflaterBufferPoolTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderDeflaterBufferPoolTest.java
@@ -3,7 +3,7 @@ package com.pngencoder;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PngEncoderDeflaterBufferPoolTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderDeflaterExecutorServiceTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderDeflaterExecutorServiceTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import java.util.concurrent.ExecutorService;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PngEncoderDeflaterExecutorServiceTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderDeflaterExecutorServiceThreadFactoryTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderDeflaterExecutorServiceThreadFactoryTest.java
@@ -3,7 +3,7 @@ package com.pngencoder;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PngEncoderDeflaterExecutorServiceThreadFactoryTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderDeflaterOutputStreamTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderDeflaterOutputStreamTest.java
@@ -16,7 +16,7 @@ import java.util.zip.InflaterOutputStream;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PngEncoderDeflaterOutputStreamTest {
     private static final int SEGMENT_MAX_LENGTH_ORIGINAL = 64 * 1024;

--- a/src/test/java/com/pngencoder/PngEncoderDeflaterSegmentResultTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderDeflaterSegmentResultTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import java.util.zip.Adler32;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PngEncoderDeflaterSegmentResultTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderDeflaterThreadLocalDeflaterTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderDeflaterThreadLocalDeflaterTest.java
@@ -7,7 +7,7 @@ import java.util.zip.Deflater;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PngEncoderDeflaterThreadLocalDeflaterTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderIdatChunksOutputStreamTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderIdatChunksOutputStreamTest.java
@@ -8,7 +8,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PngEncoderIdatChunksOutputStreamTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderScanlineUtilTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderScanlineUtilTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import java.awt.image.BufferedImage;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PngEncoderScanlineUtilTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderTest.java
@@ -15,7 +15,7 @@ import javax.imageio.metadata.IIOMetadataNode;
 import javax.imageio.stream.ImageInputStream;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PngEncoderTest {
     public static final String VALID_CHUNK_TYPE = "IDAT";


### PR DESCRIPTION
This avoids CVE-2020-15250 which has been patched in JUnit 4.13.1.

`org.junit.Assert.assertThat()` has been deprecated in favour of `org.hamcrest.MatcherAssert.assertThat()` so we switch to using that.