### PR TITLE
Update to JUnit 5 and Hamcrest 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,16 +159,10 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.7.0</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -166,8 +166,8 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-integration</artifactId>
-            <version>1.3</version>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/com/pngencoder/PngEncoderBenchmarkAssorted.java
+++ b/src/test/java/com/pngencoder/PngEncoderBenchmarkAssorted.java
@@ -1,7 +1,7 @@
 package com.pngencoder;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -9,7 +9,7 @@ import java.io.IOException;
 import javax.imageio.ImageIO;
 
 public class PngEncoderBenchmarkAssorted {
-    @Ignore("run manually")
+    @Disabled("run manually")
     @Test
     public void runBenchmarkIntelliJIdeaProfilerPngEncoder() {
         final int times = 10;
@@ -19,7 +19,7 @@ public class PngEncoderBenchmarkAssorted {
         }
     }
 
-    @Ignore("run manually")
+    @Disabled("run manually")
     @Test
     public void runBenchmarkIntelliJIdeaProfilerImageIO() {
         final int times = 1;
@@ -29,7 +29,7 @@ public class PngEncoderBenchmarkAssorted {
         }
     }
 
-    @Ignore("run manually")
+    @Disabled("run manually")
     @Test
     public void runBenchmarkCustom() throws IOException {
         Timing.message("started");

--- a/src/test/java/com/pngencoder/PngEncoderBenchmarkCompressionSpeedVsSize.java
+++ b/src/test/java/com/pngencoder/PngEncoderBenchmarkCompressionSpeedVsSize.java
@@ -1,7 +1,7 @@
 package com.pngencoder;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
@@ -28,13 +28,13 @@ public class PngEncoderBenchmarkCompressionSpeedVsSize {
             .measurementTime(TimeValue.seconds(5))
             .build();
 
-    @Ignore("run manually")
+    @Disabled("run manually")
     @Test
     public void runBenchmarkSpeed() throws Exception {
         new Runner(OPTIONS).run();
     }
 
-    @Ignore("run manually")
+    @Disabled("run manually")
     @Test
     public void runBenchmarkSize() {
         final BufferedImage bufferedImage = createTestImage();

--- a/src/test/java/com/pngencoder/PngEncoderBenchmarkPngEncoderVsImageIO.java
+++ b/src/test/java/com/pngencoder/PngEncoderBenchmarkPngEncoderVsImageIO.java
@@ -1,7 +1,7 @@
 package com.pngencoder;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
@@ -43,7 +43,7 @@ public class PngEncoderBenchmarkPngEncoderVsImageIO {
             .measurementTime(TimeValue.seconds(5))
             .build();
 
-    @Ignore("run manually")
+    @Disabled("run manually")
     @Test
     public void runBenchmark() throws Exception {
         new Runner(OPTIONS).run();

--- a/src/test/java/com/pngencoder/PngEncoderBufferedImageConverterTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderBufferedImageConverterTest.java
@@ -1,12 +1,12 @@
 package com.pngencoder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.awt.image.BufferedImage;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PngEncoderBufferedImageConverterTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderBufferedImageTypeTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderBufferedImageTypeTest.java
@@ -1,11 +1,12 @@
 package com.pngencoder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.awt.image.BufferedImage;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PngEncoderBufferedImageTypeTest {
     @Test
@@ -46,9 +47,10 @@ public class PngEncoderBufferedImageTypeTest {
         new BufferedImage(1, 1, PngEncoderBufferedImageType.values().length - 1);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void containsAllBufferedImageTypes2() {
-        new BufferedImage(1, 1, PngEncoderBufferedImageType.values().length);
+        assertThrows(IllegalArgumentException.class,
+                () -> new BufferedImage(1, 1, PngEncoderBufferedImageType.values().length));
     }
 
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderDeflaterBufferPoolTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderDeflaterBufferPoolTest.java
@@ -1,9 +1,9 @@
 package com.pngencoder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class PngEncoderDeflaterBufferPoolTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderDeflaterExecutorServiceTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderDeflaterExecutorServiceTest.java
@@ -1,11 +1,11 @@
 package com.pngencoder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutorService;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class PngEncoderDeflaterExecutorServiceTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderDeflaterExecutorServiceThreadFactoryTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderDeflaterExecutorServiceThreadFactoryTest.java
@@ -1,9 +1,9 @@
 package com.pngencoder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class PngEncoderDeflaterExecutorServiceThreadFactoryTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderDeflaterOutputStreamTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderDeflaterOutputStreamTest.java
@@ -1,6 +1,6 @@
 package com.pngencoder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -14,9 +14,10 @@ import java.util.function.BiConsumer;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterOutputStream;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PngEncoderDeflaterOutputStreamTest {
     private static final int SEGMENT_MAX_LENGTH_ORIGINAL = 64 * 1024;
@@ -79,27 +80,28 @@ public class PngEncoderDeflaterOutputStreamTest {
         assertThatBytesIsSameAfterDeflateAndInflateFast(expected, MULTI_THREADED_DEFLATER);
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void constructorThrowsIOExceptionOnWritingDeflateHeaderWithRiggedOutputStream() throws IOException {
         RiggedOutputStream riggedOutputStream = new RiggedOutputStream(1);
-        new PngEncoderDeflaterOutputStream(riggedOutputStream, PngEncoder.DEFAULT_COMPRESSION_LEVEL, SEGMENT_MAX_LENGTH_ORIGINAL);
+        assertThrows(IOException.class,
+                () -> new PngEncoderDeflaterOutputStream(riggedOutputStream, PngEncoder.DEFAULT_COMPRESSION_LEVEL, SEGMENT_MAX_LENGTH_ORIGINAL));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void finishThrowsIOExceptionOnJoiningWithRiggedOutputStream() throws IOException {
         RiggedOutputStream riggedOutputStream = new RiggedOutputStream(3);
         PngEncoderDeflaterOutputStream deflaterOutputStream = new PngEncoderDeflaterOutputStream(riggedOutputStream, PngEncoder.DEFAULT_COMPRESSION_LEVEL, SEGMENT_MAX_LENGTH_ORIGINAL);
         byte[] bytesToWrite = createRandomBytes(10);
         deflaterOutputStream.write(bytesToWrite);
-        deflaterOutputStream.finish();
+        assertThrows(IOException.class, deflaterOutputStream::finish);
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void finishThrowsIOExceptionOnJoiningWithRiggedPngEncoderDeflaterSegmentTask() throws IOException {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         PngEncoderDeflaterOutputStream deflaterOutputStream = new PngEncoderDeflaterOutputStream(byteArrayOutputStream, PngEncoder.DEFAULT_COMPRESSION_LEVEL, SEGMENT_MAX_LENGTH_ORIGINAL);
         deflaterOutputStream.submitTask(new RiggedPngEncoderDeflaterSegmentTask());
-        deflaterOutputStream.finish();
+        assertThrows(IOException.class, deflaterOutputStream::finish);
     }
 
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderDeflaterSegmentResultTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderDeflaterSegmentResultTest.java
@@ -1,11 +1,11 @@
 package com.pngencoder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.zip.Adler32;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class PngEncoderDeflaterSegmentResultTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderDeflaterThreadLocalDeflaterTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderDeflaterThreadLocalDeflaterTest.java
@@ -1,13 +1,13 @@
 package com.pngencoder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.zip.Deflater;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PngEncoderDeflaterThreadLocalDeflaterTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderIdatChunksOutputStreamTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderIdatChunksOutputStreamTest.java
@@ -1,14 +1,14 @@
 package com.pngencoder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class PngEncoderIdatChunksOutputStreamTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderScanlineUtilTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderScanlineUtilTest.java
@@ -1,11 +1,11 @@
 package com.pngencoder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.awt.image.BufferedImage;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class PngEncoderScanlineUtilTest {
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderTest.java
@@ -1,6 +1,6 @@
 package com.pngencoder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
@@ -14,8 +14,9 @@ import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.metadata.IIOMetadataNode;
 import javax.imageio.stream.ImageInputStream;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PngEncoderTest {
     public static final String VALID_CHUNK_TYPE = "IDAT";
@@ -175,19 +176,19 @@ public class PngEncoderTest {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testAsChunkTypeNull() {
-        PngEncoderLogic.asChunk(null, new byte[1]);
+        assertThrows(NullPointerException.class, () -> PngEncoderLogic.asChunk(null, new byte[1]));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAsChunkTypeInvalid() {
-        PngEncoderLogic.asChunk("chunk types must be four characters long", new byte[1]);
+        assertThrows(IllegalArgumentException.class, () -> PngEncoderLogic.asChunk("chunk types must be four characters long", new byte[1]));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testAsChunkNullBytes() {
-        PngEncoderLogic.asChunk(VALID_CHUNK_TYPE, null);
+        assertThrows(NullPointerException.class, () -> PngEncoderLogic.asChunk(VALID_CHUNK_TYPE, null));
     }
 
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderVerificationUtilTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderVerificationUtilTest.java
@@ -1,6 +1,8 @@
 package com.pngencoder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PngEncoderVerificationUtilTest {
     @Test
@@ -8,9 +10,9 @@ public class PngEncoderVerificationUtilTest {
         PngEncoderVerificationUtil.verifyCompressionLevel(-1);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void verifyCompressionLevelRejectsMinusTwo() {
-        PngEncoderVerificationUtil.verifyCompressionLevel(-2);
+        assertThrows(IllegalArgumentException.class, () -> PngEncoderVerificationUtil.verifyCompressionLevel(-2));
     }
 
     @Test
@@ -18,9 +20,9 @@ public class PngEncoderVerificationUtilTest {
         PngEncoderVerificationUtil.verifyCompressionLevel(9);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void verifyCompressionLevelRejectsTen() {
-        PngEncoderVerificationUtil.verifyCompressionLevel(10);
+        assertThrows(IllegalArgumentException.class, () -> PngEncoderVerificationUtil.verifyCompressionLevel(10));
     }
 
     @Test
@@ -28,8 +30,8 @@ public class PngEncoderVerificationUtilTest {
         PngEncoderVerificationUtil.verifyChunkType("IDAT");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void verifyChunkTypeRejectsLorem() {
-        PngEncoderVerificationUtil.verifyChunkType("Lorem");
+        assertThrows(IllegalArgumentException.class, () -> PngEncoderVerificationUtil.verifyChunkType("Lorem"));
     }
 }


### PR DESCRIPTION
This updates the tests to JUnit 5.
It imports classes from `org.junit.jupiter`, uses JUnit 5 annotations and changes to use `assertThrows()` for verifying exceptions.

It also updates the Hamcrest dependency to the latest version, and since we don't have a need for `hamcrest-integration` it changes to instead depend on the standard `org.hamcrest:hamcrest`.