### PR TITLE
Support for specifying physical pixels dimensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.pngencoder</groupId>
     <artifactId>pngencoder</artifactId>
-    <version>0.11.1-SNAPSHOT</version>
+    <version>0.12.0-physical-pixel-dimensions-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.pngencoder</groupId>
     <artifactId>pngencoder</artifactId>
-    <version>0.12.0-physical-pixel-dimensions-SNAPSHOT</version>
+    <version>0.12.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/pngencoder/PngEncoder.java
+++ b/src/main/java/com/pngencoder/PngEncoder.java
@@ -18,16 +18,19 @@ public class PngEncoder {
     private final int compressionLevel;
     private final boolean multiThreadedCompressionEnabled;
     private final PngEncoderSrgbRenderingIntent srgbRenderingIntent;
+    private final PngEncoderPhysicalPixelDimensions physicalPixelDimensions;
 
     private PngEncoder(
             BufferedImage bufferedImage,
             int compressionLevel,
             boolean multiThreadedCompressionEnabled,
-            PngEncoderSrgbRenderingIntent srgbRenderingIntent) {
+            PngEncoderSrgbRenderingIntent srgbRenderingIntent,
+            PngEncoderPhysicalPixelDimensions physicalPixelDimensions) {
         this.bufferedImage = bufferedImage;
         this.compressionLevel = PngEncoderVerificationUtil.verifyCompressionLevel(compressionLevel);
         this.multiThreadedCompressionEnabled = multiThreadedCompressionEnabled;
         this.srgbRenderingIntent = srgbRenderingIntent;
+        this.physicalPixelDimensions = physicalPixelDimensions;
     }
 
     public PngEncoder() {
@@ -35,23 +38,28 @@ public class PngEncoder {
                 null,
                 DEFAULT_COMPRESSION_LEVEL,
                 true,
+                null,
                 null);
     }
 
     public PngEncoder withBufferedImage(BufferedImage bufferedImage) {
-        return new PngEncoder(bufferedImage, compressionLevel, multiThreadedCompressionEnabled, srgbRenderingIntent);
+        return new PngEncoder(bufferedImage, compressionLevel, multiThreadedCompressionEnabled, srgbRenderingIntent, physicalPixelDimensions);
     }
 
     public PngEncoder withCompressionLevel(int compressionLevel) {
-        return new PngEncoder(bufferedImage, compressionLevel, multiThreadedCompressionEnabled, srgbRenderingIntent);
+        return new PngEncoder(bufferedImage, compressionLevel, multiThreadedCompressionEnabled, srgbRenderingIntent, physicalPixelDimensions);
     }
 
     public PngEncoder withMultiThreadedCompressionEnabled(boolean multiThreadedCompressionEnabled) {
-        return new PngEncoder(bufferedImage, compressionLevel, multiThreadedCompressionEnabled, srgbRenderingIntent);
+        return new PngEncoder(bufferedImage, compressionLevel, multiThreadedCompressionEnabled, srgbRenderingIntent, physicalPixelDimensions);
     }
 
     public PngEncoder withSrgbRenderingIntent(PngEncoderSrgbRenderingIntent srgbRenderingIntent) {
-        return new PngEncoder(bufferedImage, compressionLevel, multiThreadedCompressionEnabled, srgbRenderingIntent);
+        return new PngEncoder(bufferedImage, compressionLevel, multiThreadedCompressionEnabled, srgbRenderingIntent, physicalPixelDimensions);
+    }
+
+    public PngEncoder withPhysicalPixelDimensions(PngEncoderPhysicalPixelDimensions physicalPixelDimensions) {
+        return new PngEncoder(bufferedImage, compressionLevel, multiThreadedCompressionEnabled, srgbRenderingIntent, physicalPixelDimensions);
     }
 
     public BufferedImage getBufferedImage() {
@@ -72,7 +80,7 @@ public class PngEncoder {
 
     public int toStream(OutputStream outputStream) {
         try {
-            return PngEncoderLogic.encode(bufferedImage, outputStream, compressionLevel, multiThreadedCompressionEnabled, srgbRenderingIntent);
+            return PngEncoderLogic.encode(bufferedImage, outputStream, compressionLevel, multiThreadedCompressionEnabled, srgbRenderingIntent, physicalPixelDimensions);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/src/main/java/com/pngencoder/PngEncoderLogic.java
+++ b/src/main/java/com/pngencoder/PngEncoderLogic.java
@@ -51,7 +51,7 @@ class PngEncoderLogic {
     private PngEncoderLogic() {
     }
 
-    static int encode(BufferedImage bufferedImage, OutputStream outputStream, int compressionLevel, boolean multiThreadedCompressionEnabled, PngEncoderSrgbRenderingIntent srgbRenderingIntent) throws IOException {
+    static int encode(BufferedImage bufferedImage, OutputStream outputStream, int compressionLevel, boolean multiThreadedCompressionEnabled, PngEncoderSrgbRenderingIntent srgbRenderingIntent, PngEncoderPhysicalPixelDimensions physicalPixelDimensions) throws IOException {
         Objects.requireNonNull(bufferedImage, "bufferedImage");
         Objects.requireNonNull(outputStream, "outputStream");
 
@@ -70,6 +70,10 @@ class PngEncoderLogic {
             outputStream.write(asChunk("sRGB", new byte[]{ srgbRenderingIntent.getValue() }));
             outputStream.write(asChunk("gAMA", GAMA_SRGB_VALUE));
             outputStream.write(asChunk("cHRM", CHRM_SRGB_VALUE));
+        }
+
+        if (physicalPixelDimensions != null) {
+            outputStream.write(asChunk("pHYs", getPhysicalPixelDimensions(physicalPixelDimensions)));
         }
 
         PngEncoderIdatChunksOutputStream idatChunksOutputStream = new PngEncoderIdatChunksOutputStream(countingOutputStream);
@@ -105,6 +109,14 @@ class PngEncoderLogic {
         buffer.put(IHDR_COMPRESSION_METHOD);
         buffer.put(IHDR_FILTER_METHOD);
         buffer.put(IHDR_INTERLACE_METHOD);
+        return buffer.array();
+    }
+
+    static byte[] getPhysicalPixelDimensions(PngEncoderPhysicalPixelDimensions physicalPixelDimensions) {
+        ByteBuffer buffer = ByteBuffer.allocate(9);
+        buffer.putInt(physicalPixelDimensions.getPixelsPerUnitX());
+        buffer.putInt(physicalPixelDimensions.getPixelsPerUnitY());
+        buffer.put(physicalPixelDimensions.getUnit().getValue());
         return buffer.array();
     }
 

--- a/src/main/java/com/pngencoder/PngEncoderPhysicalPixelDimensions.java
+++ b/src/main/java/com/pngencoder/PngEncoderPhysicalPixelDimensions.java
@@ -11,7 +11,7 @@ package com.pngencoder;
 public class PngEncoderPhysicalPixelDimensions {
 
     public enum Unit {
-        UKNOWN((byte) 0),
+        UNKNOWN((byte) 0),
         METER((byte) 1);
 
         private final byte value;
@@ -57,7 +57,7 @@ public class PngEncoderPhysicalPixelDimensions {
     }
 
     public static PngEncoderPhysicalPixelDimensions aspectRatio(int pixelsPerUnitX, int pixelsPerUnitY) {
-        return new PngEncoderPhysicalPixelDimensions(pixelsPerUnitX, pixelsPerUnitY, Unit.UKNOWN);
+        return new PngEncoderPhysicalPixelDimensions(pixelsPerUnitX, pixelsPerUnitY, Unit.UNKNOWN);
     }
 
     public int getPixelsPerUnitX() {

--- a/src/main/java/com/pngencoder/PngEncoderPhysicalPixelDimensions.java
+++ b/src/main/java/com/pngencoder/PngEncoderPhysicalPixelDimensions.java
@@ -1,7 +1,7 @@
 package com.pngencoder;
 
 /**
- * Represents PNG physical piel dimensions
+ * Represents PNG physical pixel dimensions
  *
  * Use on of the static methods to create physical pixel dimensions based
  * on pixels per meter, dots per inch or a unit-less aspect ratio.

--- a/src/main/java/com/pngencoder/PngEncoderPhysicalPixelDimensions.java
+++ b/src/main/java/com/pngencoder/PngEncoderPhysicalPixelDimensions.java
@@ -3,7 +3,7 @@ package com.pngencoder;
 /**
  * Represents PNG physical pixel dimensions
  *
- * Use on of the static methods to create physical pixel dimensions based
+ * Use one of the static methods to create physical pixel dimensions based
  * on pixels per meter, dots per inch or a unit-less aspect ratio.
  *
  * @see <a href="https://www.w3.org/TR/PNG/#11pHYs">https://www.w3.org/TR/PNG/#11pHYs</a>

--- a/src/main/java/com/pngencoder/PngEncoderPhysicalPixelDimensions.java
+++ b/src/main/java/com/pngencoder/PngEncoderPhysicalPixelDimensions.java
@@ -1,0 +1,74 @@
+package com.pngencoder;
+
+/**
+ * Represents PNG physical piel dimensions
+ *
+ * Use on of the static methods to create physical pixel dimensions based
+ * on pixels per meter, dots per inch or a unit-less aspect ratio.
+ *
+ * @see <a href="https://www.w3.org/TR/PNG/#11pHYs">https://www.w3.org/TR/PNG/#11pHYs</a>
+ */
+public class PngEncoderPhysicalPixelDimensions {
+
+    public enum Unit {
+        UKNOWN((byte) 0),
+        METER((byte) 1);
+
+        private final byte value;
+
+        Unit(byte value) {
+            this.value = value;
+        }
+
+        public byte getValue() {
+            return value;
+        }
+    }
+
+    private static final float INCHES_PER_METER = 100 / 2.54f;
+
+    private final int pixelsPerUnitX;
+    private final int pixelsPerUnitY;
+    private final Unit unit;
+
+    private PngEncoderPhysicalPixelDimensions(int pixelsPerUnitX, int pixelsPerUnitY, Unit unit) {
+        this.pixelsPerUnitX = pixelsPerUnitX;
+        this.pixelsPerUnitY = pixelsPerUnitY;
+        this.unit = unit;
+    }
+
+    public static PngEncoderPhysicalPixelDimensions pixelsPerMeter(int pixelsPerMeterX, int pixelsPerMeterY) {
+        return new PngEncoderPhysicalPixelDimensions(pixelsPerMeterX, pixelsPerMeterY, Unit.METER);
+    }
+
+    public static PngEncoderPhysicalPixelDimensions pixelsPerMeter(int pixelsPerMeter) {
+        return pixelsPerMeter(pixelsPerMeter, pixelsPerMeter);
+    }
+
+    public static PngEncoderPhysicalPixelDimensions dotsPerInch(int dotsPerInchX, int dotsPerInchY) {
+        int pixelsPerMeterX = Math.round(dotsPerInchX * INCHES_PER_METER);
+        int pixelsPerMeterY = Math.round(dotsPerInchY * INCHES_PER_METER);
+
+        return new PngEncoderPhysicalPixelDimensions(pixelsPerMeterX, pixelsPerMeterY, Unit.METER);
+    }
+
+    public static PngEncoderPhysicalPixelDimensions dotsPerInch(int dotsPerInch) {
+        return dotsPerInch(dotsPerInch, dotsPerInch);
+    }
+
+    public static PngEncoderPhysicalPixelDimensions aspectRatio(int pixelsPerUnitX, int pixelsPerUnitY) {
+        return new PngEncoderPhysicalPixelDimensions(pixelsPerUnitX, pixelsPerUnitY, Unit.UKNOWN);
+    }
+
+    public int getPixelsPerUnitX() {
+        return pixelsPerUnitX;
+    }
+
+    public int getPixelsPerUnitY() {
+        return pixelsPerUnitY;
+    }
+
+    public Unit getUnit() {
+        return unit;
+    }
+}

--- a/src/main/java/com/pngencoder/PngEncoderPhysicalPixelDimensions.java
+++ b/src/main/java/com/pngencoder/PngEncoderPhysicalPixelDimensions.java
@@ -37,14 +37,37 @@ public class PngEncoderPhysicalPixelDimensions {
         this.unit = unit;
     }
 
+    /**
+     * Creates a PngEncoderPhysicalPixelDimensions with possibly non-square pixels
+     * with a size specified in pixels per meter
+     *
+     * @param pixelsPerMeterX the pixels per meter value for the horizontal dimension
+     * @param pixelsPerMeterY the pixels per meter value for the vertical dimension
+     */
     public static PngEncoderPhysicalPixelDimensions pixelsPerMeter(int pixelsPerMeterX, int pixelsPerMeterY) {
         return new PngEncoderPhysicalPixelDimensions(pixelsPerMeterX, pixelsPerMeterY, Unit.METER);
     }
 
+    /**
+     * Creates a PngEncoderPhysicalPixelDimensions with square pixels
+     * with a size specified in pixels per meter
+     *
+     * @param pixelsPerMeter the pixels per meter value for both dimensions
+     */
     public static PngEncoderPhysicalPixelDimensions pixelsPerMeter(int pixelsPerMeter) {
         return pixelsPerMeter(pixelsPerMeter, pixelsPerMeter);
     }
 
+    /**
+     * Creates a PngEncoderPhysicalPixelDimensions with possibly non-square pixels
+     * with a size specified in dots per inch
+     *
+     * Note that dots per inch (DPI) cannot be exactly represented by the PNG format's
+     * integer value for pixels per meter. There will be a slight rounding error.
+     *
+     * @param dotsPerInchX the DPI value for the horizontal dimension
+     * @param dotsPerInchY the DPI value for the vertical dimension
+     */
     public static PngEncoderPhysicalPixelDimensions dotsPerInch(int dotsPerInchX, int dotsPerInchY) {
         int pixelsPerMeterX = Math.round(dotsPerInchX * INCHES_PER_METER);
         int pixelsPerMeterY = Math.round(dotsPerInchY * INCHES_PER_METER);
@@ -52,22 +75,47 @@ public class PngEncoderPhysicalPixelDimensions {
         return new PngEncoderPhysicalPixelDimensions(pixelsPerMeterX, pixelsPerMeterY, Unit.METER);
     }
 
+    /**
+     * Creates a PngEncoderPhysicalPixelDimensions with square pixels
+     * with a size specified in dots per inch
+     *
+     * Note that dots per inch (DPI) cannot be exactly represented by the PNG format's
+     * integer value for pixels per meter. There will be a slight rounding error.
+     *
+     * @param dotsPerInch the DPI value for both dimensions
+     */
     public static PngEncoderPhysicalPixelDimensions dotsPerInch(int dotsPerInch) {
         return dotsPerInch(dotsPerInch, dotsPerInch);
     }
 
+    /**
+     * Creates a PngEncoderPhysicalPixelDimensions that only specifies the aspect ratio,
+     * but not the size, of the pixels
+     *
+     * @param pixelsPerUnitX the number of pixels per unit in the horizontal dimension
+     * @param pixelsPerUnitY the number of pixels per unit in the vertical dimension
+     */
     public static PngEncoderPhysicalPixelDimensions aspectRatio(int pixelsPerUnitX, int pixelsPerUnitY) {
         return new PngEncoderPhysicalPixelDimensions(pixelsPerUnitX, pixelsPerUnitY, Unit.UNKNOWN);
     }
 
+    /**
+     * @return the number of pixels per unit in the horizontal dimension
+     */
     public int getPixelsPerUnitX() {
         return pixelsPerUnitX;
     }
 
+    /**
+     * @return the number of pixels per unit in the vertical dimension
+     */
     public int getPixelsPerUnitY() {
         return pixelsPerUnitY;
     }
 
+    /**
+     * @return the unit of the pixel size (either {@link Unit#METER} or {@link Unit#UNKNOWN})
+     */
     public Unit getUnit() {
         return unit;
     }

--- a/src/test/java/com/pngencoder/PngEncoderPhysicalPixelDimensionsTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderPhysicalPixelDimensionsTest.java
@@ -24,7 +24,7 @@ public class PngEncoderPhysicalPixelDimensionsTest {
 
         assertThat(physicalPixelDimensions.getPixelsPerUnitX(), is(2));
         assertThat(physicalPixelDimensions.getPixelsPerUnitY(), is(3));
-        assertThat(physicalPixelDimensions.getUnit(), is(PngEncoderPhysicalPixelDimensions.Unit.UKNOWN));
+        assertThat(physicalPixelDimensions.getUnit(), is(PngEncoderPhysicalPixelDimensions.Unit.UNKNOWN));
     }
 
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderPhysicalPixelDimensionsTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderPhysicalPixelDimensionsTest.java
@@ -1,0 +1,39 @@
+package com.pngencoder;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class PngEncoderPhysicalPixelDimensionsTest {
+
+    @Test
+    public void pixelsPerMeter() {
+        PngEncoderPhysicalPixelDimensions physicalPixelDimensions =
+                PngEncoderPhysicalPixelDimensions.pixelsPerMeter(2835);
+
+        assertThat(physicalPixelDimensions.getPixelsPerUnitX(), is(2835));
+        assertThat(physicalPixelDimensions.getPixelsPerUnitY(), is(2835));
+        assertThat(physicalPixelDimensions.getUnit(), is(PngEncoderPhysicalPixelDimensions.Unit.METER));
+    }
+
+    @Test
+    public void aspectRatio() {
+        PngEncoderPhysicalPixelDimensions physicalPixelDimensions =
+                PngEncoderPhysicalPixelDimensions.aspectRatio(2, 3);
+
+        assertThat(physicalPixelDimensions.getPixelsPerUnitX(), is(2));
+        assertThat(physicalPixelDimensions.getPixelsPerUnitY(), is(3));
+        assertThat(physicalPixelDimensions.getUnit(), is(PngEncoderPhysicalPixelDimensions.Unit.UKNOWN));
+    }
+
+    @Test
+    public void dpi() {
+        PngEncoderPhysicalPixelDimensions physicalPixelDimensions =
+                PngEncoderPhysicalPixelDimensions.dotsPerInch(72);
+
+        assertThat(physicalPixelDimensions.getPixelsPerUnitX(), is(2835));
+        assertThat(physicalPixelDimensions.getPixelsPerUnitY(), is(2835));
+        assertThat(physicalPixelDimensions.getUnit(), is(PngEncoderPhysicalPixelDimensions.Unit.METER));
+    }
+}


### PR DESCRIPTION
This adds support for writing the `pHYs` (Physical pixel dimensions) chunk to encoded PNGs
(see https://www.w3.org/TR/PNG/#11pHYs).

The dimensions can be specified in either pixels per meter (which is what the PNG format uses) or in dots per inch (which is commonly used for images).