### PR TITLE
Benchmark against ObjectPlanet PngEncoder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,12 @@
             <version>1.23</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.objectplanet.image</groupId>
+            <artifactId>PngEncoder</artifactId>
+            <version>2.0.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/test/java/com/pngencoder/PngEncoderBenchmarkPngEncoderVsImageIO.java
+++ b/src/test/java/com/pngencoder/PngEncoderBenchmarkPngEncoderVsImageIO.java
@@ -93,4 +93,19 @@ public class PngEncoderBenchmarkPngEncoderVsImageIO {
     public void logo2121x350ImageIO(BenchmarkStateLogo2121x350 state) {
         PngEncoderTestUtil.encodeWithImageIO(state.bufferedImage);
     }
+
+    @Benchmark
+    public void random1024x1024ObjectPlanetPngEncoder(BenchmarkStateRandom1024x1024 state) {
+        PngEncoderTestUtil.encodeWithObjectPlanetPngEncoder(state.bufferedImage);
+    }
+
+    @Benchmark
+    public void looklet4900x6000ObjectPlanetPngEncoder(BenchmarkStateLooklet4900x6000 state) {
+        PngEncoderTestUtil.encodeWithObjectPlanetPngEncoder(state.bufferedImage);
+    }
+
+    @Benchmark
+    public void logo2121x350ObjectPlanetPngEncoder(BenchmarkStateLogo2121x350 state) {
+        PngEncoderTestUtil.encodeWithObjectPlanetPngEncoder(state.bufferedImage);
+    }
 }

--- a/src/test/java/com/pngencoder/PngEncoderTestUtil.java
+++ b/src/test/java/com/pngencoder/PngEncoderTestUtil.java
@@ -63,4 +63,13 @@ class PngEncoderTestUtil {
             throw new UncheckedIOException(e);
         }
     }
+
+    static void encodeWithObjectPlanetPngEncoder(BufferedImage bufferedImage) {
+        // https://www.objectplanet.com/pngencoder/
+        try {
+            new com.objectplanet.image.PngEncoder().encode(bufferedImage, NULL_OUTPUT_STREAM);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
 }


### PR DESCRIPTION
Website: https://www.objectplanet.com/pngencoder/

Claims to be the "worlds fastest java png encoder"

Unfortunately, the library is not available from Maven Central causing the CI to fail. Not sure how to solve that.

Benchmark on MacBook Air (M1, 2020) / Apple M1 / 8 GB / `Darwin 20.3.0 Darwin Kernel Version 20.3.0: Thu Jan 21 00:06:51 PST 2021; root:xnu-7195.81.3~1/RELEASE_ARM64_T8101 x86_64 i386 MacBookAir10,1 Darwin`

```
Benchmark                                                                       Mode  Cnt    Score   Error  Units
PngEncoderBenchmarkPngEncoderVsImageIO.logo2121x350ImageIO                     thrpt        49,776          ops/s
PngEncoderBenchmarkPngEncoderVsImageIO.logo2121x350ObjectPlanetPngEncoder      thrpt        33,192          ops/s
PngEncoderBenchmarkPngEncoderVsImageIO.logo2121x350PngEncoder                  thrpt       197,328          ops/s

PngEncoderBenchmarkPngEncoderVsImageIO.looklet4900x6000ImageIO                 thrpt         0,444          ops/s
PngEncoderBenchmarkPngEncoderVsImageIO.looklet4900x6000ObjectPlanetPngEncoder  thrpt         0,264          ops/s
PngEncoderBenchmarkPngEncoderVsImageIO.looklet4900x6000PngEncoder              thrpt         0,179          ops/s

PngEncoderBenchmarkPngEncoderVsImageIO.random1024x1024ImageIO                  thrpt         7,683          ops/s
PngEncoderBenchmarkPngEncoderVsImageIO.random1024x1024ObjectPlanetPngEncoder   thrpt        14,801          ops/s
PngEncoderBenchmarkPngEncoderVsImageIO.random1024x1024PngEncoder               thrpt        50,197          ops/s
```
