### PR TITLE
Fix stride handling

### DIFF
--- a/src/main/java/com/pngencoder/PngEncoderScanlineUtil.java
+++ b/src/main/java/com/pngencoder/PngEncoderScanlineUtil.java
@@ -148,13 +148,7 @@ class PngEncoderScanlineUtil {
 			imageRaster.getDataElements(0, y, width, 1, elements);
 			int yRowBytesOffset = y * rowByteSize;
 
-			for (int x = 0; x < width; x++) {
-				int xOffset = (x * 3);
-				int rowByteOffset = 1 + yRowBytesOffset + x * channels;
-				bytes[rowByteOffset] = elements[xOffset]; // R
-				bytes[rowByteOffset + 1] = elements[xOffset + 1]; // G
-				bytes[rowByteOffset + 2] = elements[xOffset + 2]; // B
-			}
+			System.arraycopy(elements, 0, bytes, 1 + yRowBytesOffset, elements.length);
 		}
 		return bytes;
 	}
@@ -168,14 +162,7 @@ class PngEncoderScanlineUtil {
 			imageRaster.getDataElements(0, y, width, 1, elements);
 			int yRowBytesOffset = y * rowByteSize;
 
-			for (int x = 0; x < width; x++) {
-				int xOffset = x * 4;
-				int rowByteOffset = 1 + yRowBytesOffset + x * channels;
-				bytes[rowByteOffset] = elements[xOffset]; // R
-				bytes[rowByteOffset + 1] = elements[xOffset + 1]; // G
-				bytes[rowByteOffset + 2] = elements[xOffset + 2]; // B
-				bytes[rowByteOffset + 3] = elements[xOffset + 3]; // A
-			}
+			System.arraycopy(elements, 0, bytes, 1 + yRowBytesOffset, elements.length);
 		}
 		return bytes;
 	}

--- a/src/main/java/com/pngencoder/PngEncoderScanlineUtil.java
+++ b/src/main/java/com/pngencoder/PngEncoderScanlineUtil.java
@@ -25,7 +25,7 @@ class PngEncoderScanlineUtil {
 		// TODO: TYPE_INT_ARGB_PRE
 
 		if (type == PngEncoderBufferedImageType.TYPE_INT_BGR) {
-			return getIntBgr(raster, width, height);
+			return getIntRgb(raster, width, height);
 		}
 
 		if (type == PngEncoderBufferedImageType.TYPE_3BYTE_BGR) {
@@ -68,10 +68,10 @@ class PngEncoderScanlineUtil {
 
 			for (int x = 0; x < width; x++) {
 				final int element = elements[yOffset + x];
-				int rowByteOffset = yRowBytesOffset + x * channels;
-				bytes[rowByteOffset + 1] = (byte) (element >> 16); // R
-				bytes[rowByteOffset + 2] = (byte) (element >> 8); // G
-				bytes[rowByteOffset + 3] = (byte) (element); // B
+				int rowByteOffset = 1 + yRowBytesOffset + x * channels;
+				bytes[rowByteOffset] = (byte) ((element >> 16) & 0xFF); // R
+				bytes[rowByteOffset + 1] = (byte) ((element >> 8) & 0xFF); // G
+				bytes[rowByteOffset + 2] = (byte) ((element) & 0xFF); // B
 			}
 		}
 		return bytes;
@@ -88,11 +88,11 @@ class PngEncoderScanlineUtil {
 
 			for (int x = 0; x < width; x++) {
 				final int element = elements[yOffset + x];
-				int rowByteOffset = yRowBytesOffset + x * channels;
-				bytes[rowByteOffset + 1] = (byte) (element >> 16); // R
-				bytes[rowByteOffset + 2] = (byte) (element >> 8); // G
-				bytes[rowByteOffset + 3] = (byte) (element); // B
-				bytes[rowByteOffset + 4] = (byte) (element >> 24); // A
+				int rowByteOffset = 1 + yRowBytesOffset + x * channels;
+				bytes[rowByteOffset] = (byte) ((element >> 16) & 0xFF); // R
+				bytes[rowByteOffset + 1] = (byte) ((element >> 8) & 0xFF); // G
+				bytes[rowByteOffset + 2] = (byte) ((element) & 0xFF); // B
+				bytes[rowByteOffset + 3] = (byte) ((element >> 24) & 0xFF); // A
 			}
 		}
 		return bytes;
@@ -109,10 +109,10 @@ class PngEncoderScanlineUtil {
 
 			for (int x = 0; x < width; x++) {
 				final int element = elements[x];
-				int rowByteOffset = yRowBytesOffset + x * channels;
-				bytes[rowByteOffset + 1] = (byte) (element >> 16); // R
-				bytes[rowByteOffset + 2] = (byte) (element >> 8); // G
-				bytes[rowByteOffset + 3] = (byte) (element); // B
+				int rowByteOffset = 1 + yRowBytesOffset + x * channels;
+				bytes[rowByteOffset] = (byte) ((element >> 16) & 0xFF); // R
+				bytes[rowByteOffset + 1] = (byte) ((element >> 8) & 0xFF); // G
+				bytes[rowByteOffset + 2] = (byte) ((element) & 0xFF); // B
 			}
 		}
 		return bytes;
@@ -129,31 +129,11 @@ class PngEncoderScanlineUtil {
 
 			for (int x = 0; x < width; x++) {
 				final int element = elements[x];
-				int rowByteOffset = yRowBytesOffset + x * channels;
-				bytes[rowByteOffset + 1] = (byte) (element >> 16); // R
-				bytes[rowByteOffset + 2] = (byte) (element >> 8); // G
-				bytes[rowByteOffset + 3] = (byte) (element); // B
-				bytes[rowByteOffset + 4] = (byte) (element >> 24); // A
-			}
-		}
-		return bytes;
-	}
-
-	static byte[] getIntBgr(WritableRaster imageRaster, int width, int height) {
-		final int channels = 3;
-		final int rowByteSize = 1 + channels * width;
-		final byte[] bytes = new byte[rowByteSize * height];
-		final int[] elements = new int[width];
-		for (int y = 0; y < height; y++) {
-			imageRaster.getDataElements(0, y, width, 1, elements);
-			int yRowBytesOffset = y * rowByteSize;
-
-			for (int x = 0; x < width; x++) {
-				final int element = elements[x];
-				int rowByteOffset = yRowBytesOffset + x * channels;
-				bytes[rowByteOffset + 1] = (byte) (element); // R
-				bytes[rowByteOffset + 2] = (byte) (element >> 8); // G
-				bytes[rowByteOffset + 3] = (byte) (element >> 16); // B
+				int rowByteOffset = 1 + yRowBytesOffset + x * channels;
+				bytes[rowByteOffset] = (byte) ((element >> 16) & 0xFF); // R
+				bytes[rowByteOffset + 1] = (byte) ((element >> 8) & 0xFF); // G
+				bytes[rowByteOffset + 2] = (byte) ((element) & 0xFF); // B
+				bytes[rowByteOffset + 3] = (byte) ((element >> 24) & 0xFF); // A
 			}
 		}
 		return bytes;
@@ -170,10 +150,10 @@ class PngEncoderScanlineUtil {
 
 			for (int x = 0; x < width; x++) {
 				int xOffset = (x * 3);
-				int rowByteOffset = yRowBytesOffset + x * channels;
-				bytes[rowByteOffset + 1] = elements[xOffset + 2]; // R
-				bytes[rowByteOffset + 2] = elements[xOffset + 1]; // G
-				bytes[rowByteOffset + 3] = elements[xOffset]; // B
+				int rowByteOffset = 1 + yRowBytesOffset + x * channels;
+				bytes[rowByteOffset] = elements[xOffset]; // R
+				bytes[rowByteOffset + 1] = elements[xOffset + 1]; // G
+				bytes[rowByteOffset + 2] = elements[xOffset + 2]; // B
 			}
 		}
 		return bytes;
@@ -190,11 +170,11 @@ class PngEncoderScanlineUtil {
 
 			for (int x = 0; x < width; x++) {
 				int xOffset = x * 4;
-				int rowByteOffset = yRowBytesOffset + x * channels;
-				bytes[rowByteOffset + 1] = elements[xOffset + 3]; // R
-				bytes[rowByteOffset + 2] = elements[xOffset + 2]; // G
-				bytes[rowByteOffset + 3] = elements[xOffset + 1]; // B
-				bytes[rowByteOffset + 4] = elements[xOffset]; // A
+				int rowByteOffset = 1 + yRowBytesOffset + x * channels;
+				bytes[rowByteOffset] = elements[xOffset]; // R
+				bytes[rowByteOffset + 1] = elements[xOffset + 1]; // G
+				bytes[rowByteOffset + 2] = elements[xOffset + 2]; // B
+				bytes[rowByteOffset + 3] = elements[xOffset + 3]; // A
 			}
 		}
 		return bytes;
@@ -211,10 +191,10 @@ class PngEncoderScanlineUtil {
 
 			for (int x = 0; x < width; x++) {
 				byte grayColorValue = elements[x];
-				int rowByteOffset = yRowBytesOffset + x * channels;
-				bytes[rowByteOffset + 1] = grayColorValue; // R
-				bytes[rowByteOffset + 2] = grayColorValue; // G
-				bytes[rowByteOffset + 3] = grayColorValue; // B
+				int rowByteOffset = 1 + yRowBytesOffset + x * channels;
+				bytes[rowByteOffset] = grayColorValue; // R
+				bytes[rowByteOffset + 1] = grayColorValue; // G
+				bytes[rowByteOffset + 2] = grayColorValue; // B
 			}
 		}
 		return bytes;
@@ -233,11 +213,11 @@ class PngEncoderScanlineUtil {
 
 			for (int x = 0; x < width; x++) {
 				byte grayColorValue = (byte) (elements[x] >> 8);
-				int rowByteOffset = yRowBytesOffset + x * channels;
+				int rowByteOffset = 1 + yRowBytesOffset + x * channels;
 
-				bytes[rowByteOffset + 1] = grayColorValue; // R
-				bytes[rowByteOffset + 2] = grayColorValue; // G
-				bytes[rowByteOffset + 3] = grayColorValue; // B
+				bytes[rowByteOffset] = grayColorValue; // R
+				bytes[rowByteOffset + 1] = grayColorValue; // G
+				bytes[rowByteOffset + 2] = grayColorValue; // B
 			}
 		}
 		return bytes;

--- a/src/main/java/com/pngencoder/PngEncoderScanlineUtil.java
+++ b/src/main/java/com/pngencoder/PngEncoderScanlineUtil.java
@@ -25,7 +25,7 @@ class PngEncoderScanlineUtil {
 		// TODO: TYPE_INT_ARGB_PRE
 
 		if (type == PngEncoderBufferedImageType.TYPE_INT_BGR) {
-			return getIntRgb(raster, width, height);
+			return getIntBgr(raster, width, height);
 		}
 
 		if (type == PngEncoderBufferedImageType.TYPE_3BYTE_BGR) {
@@ -138,6 +138,28 @@ class PngEncoderScanlineUtil {
 		}
 		return bytes;
 	}
+
+	static byte[] getIntBgr(WritableRaster imageRaster, int width, int height) {
+		final int channels = 3;
+		final int rowByteSize = 1 + channels * width;
+		final byte[] bytes = new byte[rowByteSize * height];
+		final int[] elements = new int[width];
+		for (int y = 0; y < height; y++) {
+			imageRaster.getDataElements(0, y, width, 1, elements);
+			int yRowBytesOffset = y * rowByteSize;
+
+			for (int x = 0; x < width; x++) {
+				final int element = elements[x];
+				int rowByteOffset = yRowBytesOffset + x * channels;
+				bytes[rowByteOffset + 1] = (byte) (element); // R
+				bytes[rowByteOffset + 2] = (byte) (element >> 8); // G
+				bytes[rowByteOffset + 3] = (byte) (element >> 16); // B
+			}
+		}
+		return bytes;
+	}
+
+
 
 	static byte[] get3ByteBgr(WritableRaster imageRaster, int width, int height) {
 		final int channels = 3;

--- a/src/main/java/com/pngencoder/PngEncoderScanlineUtil.java
+++ b/src/main/java/com/pngencoder/PngEncoderScanlineUtil.java
@@ -69,9 +69,9 @@ class PngEncoderScanlineUtil {
 			for (int x = 0; x < width; x++) {
 				final int element = elements[yOffset + x];
 				int rowByteOffset = 1 + yRowBytesOffset + x * channels;
-				bytes[rowByteOffset] = (byte) ((element >> 16) & 0xFF); // R
-				bytes[rowByteOffset + 1] = (byte) ((element >> 8) & 0xFF); // G
-				bytes[rowByteOffset + 2] = (byte) ((element) & 0xFF); // B
+				bytes[rowByteOffset] = (byte) (element >> 16); // R
+				bytes[rowByteOffset + 1] = (byte) (element >> 8); // G
+				bytes[rowByteOffset + 2] = (byte) element; // B
 			}
 		}
 		return bytes;
@@ -89,10 +89,10 @@ class PngEncoderScanlineUtil {
 			for (int x = 0; x < width; x++) {
 				final int element = elements[yOffset + x];
 				int rowByteOffset = 1 + yRowBytesOffset + x * channels;
-				bytes[rowByteOffset] = (byte) ((element >> 16) & 0xFF); // R
-				bytes[rowByteOffset + 1] = (byte) ((element >> 8) & 0xFF); // G
-				bytes[rowByteOffset + 2] = (byte) ((element) & 0xFF); // B
-				bytes[rowByteOffset + 3] = (byte) ((element >> 24) & 0xFF); // A
+				bytes[rowByteOffset] = (byte) (element >> 16); // R
+				bytes[rowByteOffset + 1] = (byte) (element >> 8); // G
+				bytes[rowByteOffset + 2] = (byte) element; // B
+				bytes[rowByteOffset + 3] = (byte) (element >> 24); // A
 			}
 		}
 		return bytes;
@@ -110,9 +110,9 @@ class PngEncoderScanlineUtil {
 			for (int x = 0; x < width; x++) {
 				final int element = elements[x];
 				int rowByteOffset = 1 + yRowBytesOffset + x * channels;
-				bytes[rowByteOffset] = (byte) ((element >> 16) & 0xFF); // R
-				bytes[rowByteOffset + 1] = (byte) ((element >> 8) & 0xFF); // G
-				bytes[rowByteOffset + 2] = (byte) ((element) & 0xFF); // B
+				bytes[rowByteOffset] = (byte) (element >> 16); // R
+				bytes[rowByteOffset + 1] = (byte) (element >> 8); // G
+				bytes[rowByteOffset + 2] = (byte) element; // B
 			}
 		}
 		return bytes;
@@ -130,10 +130,10 @@ class PngEncoderScanlineUtil {
 			for (int x = 0; x < width; x++) {
 				final int element = elements[x];
 				int rowByteOffset = 1 + yRowBytesOffset + x * channels;
-				bytes[rowByteOffset] = (byte) ((element >> 16) & 0xFF); // R
-				bytes[rowByteOffset + 1] = (byte) ((element >> 8) & 0xFF); // G
-				bytes[rowByteOffset + 2] = (byte) ((element) & 0xFF); // B
-				bytes[rowByteOffset + 3] = (byte) ((element >> 24) & 0xFF); // A
+				bytes[rowByteOffset] = (byte) (element >> 16); // R
+				bytes[rowByteOffset + 1] = (byte) (element >> 8); // G
+				bytes[rowByteOffset + 2] = (byte) element; // B
+				bytes[rowByteOffset + 3] = (byte) (element >> 24); // A
 			}
 		}
 		return bytes;
@@ -158,8 +158,6 @@ class PngEncoderScanlineUtil {
 		}
 		return bytes;
 	}
-
-
 
 	static byte[] get3ByteBgr(WritableRaster imageRaster, int width, int height) {
 		final int channels = 3;

--- a/src/test/java/com/pngencoder/PngEncoderScanlineUtilTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderScanlineUtilTest.java
@@ -51,6 +51,11 @@ public class PngEncoderScanlineUtilTest {
         assertThatScanlineOfTestImageEqualsIntRgbOrArgb(PngEncoderBufferedImageType.TYPE_USHORT_GRAY, false);
     }
 
+    @Test
+    public void getBinary() {
+        assertThatScanlineOfTestImageEqualsIntRgbOrArgb(PngEncoderBufferedImageType.TYPE_BYTE_BINARY, false);
+    }
+
     private void assertThatScanlineOfTestImageEqualsIntRgbOrArgb(PngEncoderBufferedImageType type, boolean alpha) {
         final BufferedImage bufferedImage = PngEncoderTestUtil.createTestImage(type);
         final BufferedImage bufferedImageEnsured = PngEncoderBufferedImageConverter.ensureType(bufferedImage, alpha ? PngEncoderBufferedImageType.TYPE_INT_ARGB : PngEncoderBufferedImageType.TYPE_INT_RGB);


### PR DESCRIPTION
Currently the pngencoder does not correctly handle when a line stride is != width*channels.

This happens when you e.g. read an image which is encoded as TYPE_3BYTE_BGR. The line stride will (sometimes) get some padding to align to 4 byte boundaries. I.e. ImageOptim is able to produce such images. When they are read with ImageIO they get this padding. 

The correct way to get the image data from an image is using `imageRaster.getDataElements(0, y, width, 1, elements);`

In this patch the elements are processed row by row to at least try to reuse some CPU cache lines. I did not do benchmarks, but this version should be faster.

At least it's more correct regarding the handling of strides. 

Note: I did spent some time optimizing the lossless image encoder in PDFBox (which more or less just writes a PNG inside the PDF). See https://issues.apache.org/jira/browse/PDFBOX-4184 - so I am not completely new to this. At the moment I try to get rid of the com.objectplanet.image.PngEncoder by replacing it's usage with this library.