### PR TITLE
Loop benchmark for more "stable" results

### DIFF
--- a/src/test/java/com/pngencoder/PngEncoderBenchmarkAssorted.java
+++ b/src/test/java/com/pngencoder/PngEncoderBenchmarkAssorted.java
@@ -29,6 +29,8 @@ public class PngEncoderBenchmarkAssorted {
         }
     }
 
+    private final static boolean DISALBE_IMAGE_IO = false;
+
     @Disabled("run manually")
     @Test
     public void runBenchmarkCustom() throws IOException {
@@ -40,25 +42,32 @@ public class PngEncoderBenchmarkAssorted {
 
         final File outImageIO = File.createTempFile("out-imageio", ".png");
         //final File outPngEncoder = File.createTempFile("out-pngencoder", ".png");
-        final File outPngEncoder = new File("/Users/olof/Desktop/out.png");
+        final File outPngEncoder = new File("target/test/assorted_out.png");
+        System.out.println(outPngEncoder.getAbsolutePath());
+        outPngEncoder.getParentFile().mkdir();
 
-        ImageIO.write(original, "png", outImageIO);
-        Timing.message("ImageIO Warmup");
+        if (!DISALBE_IMAGE_IO) {
+            ImageIO.write(original, "png", outImageIO);
+            Timing.message("ImageIO Warmup");
 
-        ImageIO.write(original, "png", outImageIO);
-        Timing.message("ImageIO Result");
+            ImageIO.write(original, "png", outImageIO);
+            Timing.message("ImageIO Result");
+        }
 
         PngEncoder pngEncoder = new PngEncoder()
-                //.withMultiThreadedCompressionEnabled(false)
-                .withCompressionLevel(9)
+                .withMultiThreadedCompressionEnabled(true)
+                //.withPredictorEncoding(true)
+                .withCompressionLevel(4)
                 .withBufferedImage(original);
         System.out.println(outPngEncoder);
 
         pngEncoder.toFile(outPngEncoder);
         Timing.message("PngEncoder Warmup");
 
-        pngEncoder.toFile(outPngEncoder);
-        Timing.message("PngEncoder Result");
+        for (int i = 0; i < 10; i++) {
+            pngEncoder.toFile(outPngEncoder);
+            Timing.message("PngEncoder Result " + i);
+        }
 
         final long imageIOSize = outImageIO.length();
         final long pngEncoderSize = outPngEncoder.length();


### PR DESCRIPTION
So that I can compare my changes relative to the master branch.

This is the first PR in a series of PRs to get my changes "upstream".

This are the current results (on a Mac Studio M1 Max with JDK17):

```
No predictor, Zip Level 4 master branch 

[0] started
[1049] loaded
/Users/emmy/prjs/3rdparty/pngencoder/target/test/assorted_out.png
[1855] ImageIO Warmup
[1818] ImageIO Result
target/test/assorted_out.png
[231] PngEncoder Warmup
[207] PngEncoder Result 0
[194] PngEncoder Result 1
[192] PngEncoder Result 2
[207] PngEncoder Result 3
[203] PngEncoder Result 4
[192] PngEncoder Result 5
[204] PngEncoder Result 6
[191] PngEncoder Result 7
[191] PngEncoder Result 8
[217] PngEncoder Result 9
imageIOSize: 24503137
pngEncoderSize: 24505043
pngEncoderSize / imageIOSize: 1.0000777859585896
```

When using my development branch (https://github.com/rototor/pngencoder/tree/0.12.1-rototor) I get this results:

```
No Predictor, Zip level 4 0.12.1-rototor branch:

[0] started
[863] loaded
/Users/emmy/prjs/3rdparty/pngencoder/target/test/assorted_out.png
[1946] ImageIO Warmup
[1762] ImageIO Result
target/test/assorted_out.png
[190] PngEncoder Warmup
[187] PngEncoder Result 0
[229] PngEncoder Result 1
[167] PngEncoder Result 2
[166] PngEncoder Result 3
[166] PngEncoder Result 4
[174] PngEncoder Result 5
[173] PngEncoder Result 6
[188] PngEncoder Result 7
[176] PngEncoder Result 8
[182] PngEncoder Result 9
imageIOSize: 24503137
pngEncoderSize: 24505043
pngEncoderSize / imageIOSize: 1.0000777859585896
```
When enabling predictor encoding:
```
Predictor, Zip Level 4:
[0] started
[855] loaded
/Users/emmy/prjs/3rdparty/pngencoder/target/test/assorted_out.png
[1858] ImageIO Warmup
[1802] ImageIO Result
target/test/assorted_out.png
[554] PngEncoder Warmup
[501] PngEncoder Result 0
[501] PngEncoder Result 1
[502] PngEncoder Result 2
[505] PngEncoder Result 3
[502] PngEncoder Result 4
[505] PngEncoder Result 5
[499] PngEncoder Result 6
[498] PngEncoder Result 7
[498] PngEncoder Result 8
[496] PngEncoder Result 9
imageIOSize: 24503137
pngEncoderSize: 22876012
pngEncoderSize / imageIOSize: 0.9335952372139127
```
Zip level 4 is the default compression used by ImageIO.

So my development branch is a little bit faster than the current version while being more correct. When comparing the times using zip level 9 it's obvious that predictor encoding really ensure a better compression, but also lets the zip compressor work harder.

```
No Predictor, Zip level 9 0.12.1-rototor branch:
[0] started
[884] loaded
/Users/emmy/prjs/3rdparty/pngencoder/target/test/assorted_out.png
[1854] ImageIO Warmup
[1867] ImageIO Result
target/test/assorted_out.png
[4881] PngEncoder Warmup
[5207] PngEncoder Result 0
[4832] PngEncoder Result 1
[4844] PngEncoder Result 2
[4829] PngEncoder Result 3
[4870] PngEncoder Result 4
[4831] PngEncoder Result 5
[4970] PngEncoder Result 6
[5040] PngEncoder Result 7
[4899] PngEncoder Result 8
[5010] PngEncoder Result 9
imageIOSize: 24503137
pngEncoderSize: 21649511
pngEncoderSize / imageIOSize: 0.8835403809724445
```

```
Predictor, Zip level 9 0.12.1-rototor branch:
[0] started
[939] loaded
/Users/emmy/prjs/3rdparty/pngencoder/target/test/assorted_out.png
[1830] ImageIO Warmup
[1827] ImageIO Result
target/test/assorted_out.png
[8410] PngEncoder Warmup
[8073] PngEncoder Result 0
[8827] PngEncoder Result 1
[7978] PngEncoder Result 2
[7927] PngEncoder Result 3
[7924] PngEncoder Result 4
[8405] PngEncoder Result 5
[7935] PngEncoder Result 6
[7938] PngEncoder Result 7
[8163] PngEncoder Result 8
[8089] PngEncoder Result 9
imageIOSize: 24503137
pngEncoderSize: 19632557
pngEncoderSize / imageIOSize: 0.801226267477507

Process finished with exit code 0

```

Without multithreading the benchmark with zip level 9 takes around 38 seconds without predictor, and 64 seconds with predictor enabled. I did not let those benchmark runs finish, as it just took to long for me :)

```
No Predictor, Zip level 1 0.12.1-rototor branch:
[0] started
[976] loaded
/Users/emmy/prjs/3rdparty/pngencoder/target/test/assorted_out.png
[1878] ImageIO Warmup
[1826] ImageIO Result
target/test/assorted_out.png
[114] PngEncoder Warmup
[106] PngEncoder Result 0
[88] PngEncoder Result 1
[88] PngEncoder Result 2
[88] PngEncoder Result 3
[88] PngEncoder Result 4
[89] PngEncoder Result 5
[102] PngEncoder Result 6
[91] PngEncoder Result 7
[92] PngEncoder Result 8
[94] PngEncoder Result 9
imageIOSize: 24503137
pngEncoderSize: 26564074
pngEncoderSize / imageIOSize: 1.0841091081521521
```


```
Predictor, Zip level 1 0.12.1-rototor branch:
0] started
[869] loaded
/Users/emmy/prjs/3rdparty/pngencoder/target/test/assorted_out.png
[1891] ImageIO Warmup
[1799] ImageIO Result
target/test/assorted_out.png
[536] PngEncoder Warmup
[488] PngEncoder Result 0
[486] PngEncoder Result 1
[488] PngEncoder Result 2
[484] PngEncoder Result 3
[483] PngEncoder Result 4
[480] PngEncoder Result 5
[486] PngEncoder Result 6
[482] PngEncoder Result 7
[482] PngEncoder Result 8
[482] PngEncoder Result 9
imageIOSize: 24503137
pngEncoderSize: 25396911
pngEncoderSize / imageIOSize: 1.036475901024428
```
The predictor add a massive overhead, but with zip level > 0 it always is a size win.

```
No Predictor Zip Level 0  0.12.1-rototor branch:

[0] started
[883] loaded
/Users/emmy/prjs/3rdparty/pngencoder/target/test/assorted_out.png
[1894] ImageIO Warmup
[1831] ImageIO Result
target/test/assorted_out.png
[65] PngEncoder Warmup
[54] PngEncoder Result 0
[58] PngEncoder Result 1
[52] PngEncoder Result 2
[49] PngEncoder Result 3
[50] PngEncoder Result 4
[51] PngEncoder Result 5
[52] PngEncoder Result 6
[50] PngEncoder Result 7
[55] PngEncoder Result 8
[80] PngEncoder Result 9
imageIOSize: 24503137
pngEncoderSize: 88214360
pngEncoderSize / imageIOSize: 3.6001251594846817
```

```
Predictor Zip Level 0  0.12.1-rototor branch:

[0] started
[936] loaded
/Users/emmy/prjs/3rdparty/pngencoder/target/test/assorted_out.png
[1903] ImageIO Warmup
[1899] ImageIO Result
target/test/assorted_out.png
[540] PngEncoder Warmup
[495] PngEncoder Result 0
[495] PngEncoder Result 1
[488] PngEncoder Result 2
[491] PngEncoder Result 3
[484] PngEncoder Result 4
[490] PngEncoder Result 5
[485] PngEncoder Result 6
[484] PngEncoder Result 7
[485] PngEncoder Result 8
[481] PngEncoder Result 9
imageIOSize: 24503137
pngEncoderSize: 88214360
pngEncoderSize / imageIOSize: 3.6001251594846817
```

These results will be different for you depending on the processor used and it's configuration. 