### PR TITLE
Java 8 compatibility: Use Checksum::update(byte[], start, length)

### DIFF
--- a/src/main/java/com/pngencoder/PngEncoderIdatChunksOutputStream.java
+++ b/src/main/java/com/pngencoder/PngEncoderIdatChunksOutputStream.java
@@ -73,7 +73,7 @@ class PngEncoderIdatChunksOutputStream extends FilterOutputStream {
         out.write(IDAT_BYTES);
         out.write(b, off, len);
         crc.reset();
-        crc.update(IDAT_BYTES);
+        crc.update(IDAT_BYTES, 0, IDAT_BYTES.length);
         crc.update(b, off, len);
         writeInt((int) crc.getValue());
     }


### PR DESCRIPTION
Checksum::update(byte[]) is only available since Java 9.

As an alternative you could just raise the Java level to 11. But this would be the only place where a high Java level is needed.