### PR TITLE
Only create the thread local Deflater on demand.

### DIFF
--- a/src/main/java/com/pngencoder/PngEncoderDeflaterThreadLocalDeflater.java
+++ b/src/main/java/com/pngencoder/PngEncoderDeflaterThreadLocalDeflater.java
@@ -4,7 +4,7 @@ import java.util.zip.Deflater;
 
 /**
  * We save time by allocating and reusing some thread local state.
- *
+ * <p>
  * Creating a new Deflater instance takes a surprising amount of time.
  * Resetting an existing Deflater instance is almost free though.
  */
@@ -19,14 +19,15 @@ class PngEncoderDeflaterThreadLocalDeflater {
 
     private PngEncoderDeflaterThreadLocalDeflater() {
         this.deflaters = new Deflater[11];
-        for (int compressionLevel = -1; compressionLevel <= 9; compressionLevel++) {
-            boolean nowrap = true;
-            this.deflaters[compressionLevel + 1] = new Deflater(compressionLevel, nowrap);
-        }
     }
 
     private Deflater getDeflater(int compressionLevel) {
         Deflater deflater = this.deflaters[compressionLevel + 1];
+        if (deflater == null) {
+            boolean nowrap = true;
+            deflater = new Deflater(compressionLevel, nowrap);
+            this.deflaters[compressionLevel + 1] = deflater;
+        }
         deflater.reset();
         return deflater;
     }


### PR DESCRIPTION
When getting a Deflater this has no performance implication. The JVM has
to do a null check on the deflater anyway before calling deflater.reset().

With this explicit null check (and the lazy initialisation) the JVM now
can prove that the deflater can not be null when calling reset() and can therefor
remove the null check on the reset() call.

This change saves a bit on native JNI resources (i.e. not used Deflaters, as usually
you are compressing all images with the same compression level).