### PR TITLE
Predictor encoding and sub image fixes

### DIFF
--- a/src/main/java/com/pngencoder/PngEncoderLogic.java
+++ b/src/main/java/com/pngencoder/PngEncoderLogic.java
@@ -57,7 +57,7 @@ class PngEncoderLogic {
 
     static int encode(BufferedImage bufferedImage, OutputStream outputStream, int compressionLevel,
             boolean multiThreadedCompressionEnabled, PngEncoderSrgbRenderingIntent srgbRenderingIntent,
-            PngEncoderPhysicalPixelDimensions physicalPixelDimensions, boolean usePreditor) throws IOException {
+            PngEncoderPhysicalPixelDimensions physicalPixelDimensions, boolean usePredictor) throws IOException {
         Objects.requireNonNull(bufferedImage, "bufferedImage");
         Objects.requireNonNull(outputStream, "outputStream");
 
@@ -91,7 +91,7 @@ class PngEncoderLogic {
                 countingOutputStream);
         int estimatedBytes = metaInfo.rowByteSize * bufferedImage.getHeight();
         final int segmentMaxLengthOriginal = PngEncoderDeflaterOutputStream.getSegmentMaxLengthOriginal(estimatedBytes);
-        if (usePreditor) {
+        if (usePredictor) {
             if (estimatedBytes <= segmentMaxLengthOriginal || !multiThreadedCompressionEnabled) {
                 Deflater deflater = new Deflater(compressionLevel);
                 DeflaterOutputStream deflaterOutputStream = new DeflaterOutputStream(idatChunksOutputStream, deflater);

--- a/src/main/java/com/pngencoder/PngEncoderLogic.java
+++ b/src/main/java/com/pngencoder/PngEncoderLogic.java
@@ -1,7 +1,10 @@
 package com.pngencoder;
 
-import java.awt.Transparency;
+import com.pngencoder.PngEncoderScanlineUtil.AbstractPNGLineConsumer;
+
+import java.awt.color.ICC_Profile;
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
@@ -23,8 +26,9 @@ class PngEncoderLogic {
     // This is the "file ending"
     static final byte[] FILE_ENDING = {0, 0, 0, 0, 73, 69, 78, 68, -82, 66, 96, -126};
 
-    static final byte IHDR_BIT_DEPTH = 8;
+    static final byte IHDR_COLOR_TYPE_GREY = 0;
     static final byte IHDR_COLOR_TYPE_RGB = 2;
+    static final byte IHDR_COLOR_TYPE_GREY_ALPHA = 4;
     static final byte IHDR_COLOR_TYPE_RGBA = 6;
     static final byte IHDR_COMPRESSION_METHOD = 0;
     static final byte IHDR_FILTER_METHOD = 0;
@@ -51,23 +55,25 @@ class PngEncoderLogic {
     private PngEncoderLogic() {
     }
 
-    static int encode(BufferedImage bufferedImage, OutputStream outputStream, int compressionLevel, boolean multiThreadedCompressionEnabled, PngEncoderSrgbRenderingIntent srgbRenderingIntent, PngEncoderPhysicalPixelDimensions physicalPixelDimensions) throws IOException {
+    static int encode(BufferedImage bufferedImage, OutputStream outputStream, int compressionLevel,
+            boolean multiThreadedCompressionEnabled, PngEncoderSrgbRenderingIntent srgbRenderingIntent,
+            PngEncoderPhysicalPixelDimensions physicalPixelDimensions, boolean usePreditor) throws IOException {
         Objects.requireNonNull(bufferedImage, "bufferedImage");
         Objects.requireNonNull(outputStream, "outputStream");
 
-        final boolean alpha = bufferedImage.getTransparency() != Transparency.OPAQUE;
+        PngEncoderScanlineUtil.EncodingMetaInfo metaInfo = PngEncoderScanlineUtil.getEncodingMetaInfo(bufferedImage);
         final int width = bufferedImage.getWidth();
         final int height = bufferedImage.getHeight();
         final PngEncoderCountingOutputStream countingOutputStream = new PngEncoderCountingOutputStream(outputStream);
 
         countingOutputStream.write(FILE_BEGINNING);
 
-        final byte[] ihdr = getIhdrHeader(width, height, alpha);
+        final byte[] ihdr = getIhdrHeader(width, height, metaInfo);
         final byte[] ihdrChunk = asChunk("IHDR", ihdr);
         countingOutputStream.write(ihdrChunk);
 
-        if (srgbRenderingIntent != null) {
-            outputStream.write(asChunk("sRGB", new byte[]{ srgbRenderingIntent.getValue() }));
+        if (srgbRenderingIntent != null && metaInfo.colorProfile == null) {
+            outputStream.write(asChunk("sRGB", new byte[]{srgbRenderingIntent.getValue()}));
             outputStream.write(asChunk("gAMA", GAMA_SRGB_VALUE));
             outputStream.write(asChunk("cHRM", CHRM_SRGB_VALUE));
         }
@@ -76,23 +82,52 @@ class PngEncoderLogic {
             outputStream.write(asChunk("pHYs", getPhysicalPixelDimensions(physicalPixelDimensions)));
         }
 
-        PngEncoderIdatChunksOutputStream idatChunksOutputStream = new PngEncoderIdatChunksOutputStream(countingOutputStream);
-        final byte[] scanlineBytes = PngEncoderScanlineUtil.get(bufferedImage);
-
-        final int segmentMaxLengthOriginal = PngEncoderDeflaterOutputStream.getSegmentMaxLengthOriginal(scanlineBytes.length);
-
-        if (scanlineBytes.length <= segmentMaxLengthOriginal || !multiThreadedCompressionEnabled) {
-            Deflater deflater = new Deflater(compressionLevel);
-            DeflaterOutputStream deflaterOutputStream = new DeflaterOutputStream(idatChunksOutputStream, deflater);
-            deflaterOutputStream.write(scanlineBytes);
-            deflaterOutputStream.finish();
-            deflaterOutputStream.flush();
-        } else {
-            PngEncoderDeflaterOutputStream deflaterOutputStream = new PngEncoderDeflaterOutputStream(idatChunksOutputStream, compressionLevel, segmentMaxLengthOriginal);
-            deflaterOutputStream.write(scanlineBytes);
-            deflaterOutputStream.finish();
+        if (metaInfo.colorProfile != null) {
+            byte[] iCCP = getICCP(metaInfo.colorProfile);
+            outputStream.write(asChunk("iCCP", iCCP));
         }
 
+        PngEncoderIdatChunksOutputStream idatChunksOutputStream = new PngEncoderIdatChunksOutputStream(
+                countingOutputStream);
+        int estimatedBytes = metaInfo.rowByteSize * bufferedImage.getHeight();
+        final int segmentMaxLengthOriginal = PngEncoderDeflaterOutputStream.getSegmentMaxLengthOriginal(estimatedBytes);
+        if (usePreditor) {
+            if (estimatedBytes <= segmentMaxLengthOriginal || !multiThreadedCompressionEnabled) {
+                Deflater deflater = new Deflater(compressionLevel);
+                DeflaterOutputStream deflaterOutputStream = new DeflaterOutputStream(idatChunksOutputStream, deflater);
+                PngEncoderPredictor.encodeImageSingleThreaded(bufferedImage,  metaInfo, deflaterOutputStream);
+                deflaterOutputStream.finish();
+                deflaterOutputStream.flush();
+            } else {
+                PngEncoderDeflaterOutputStream deflaterOutputStream = new PngEncoderDeflaterOutputStream(
+                        idatChunksOutputStream, compressionLevel, segmentMaxLengthOriginal);
+                PngEncoderPredictor.encodeImageMultiThreaded(bufferedImage, metaInfo, deflaterOutputStream);
+                deflaterOutputStream.finish();
+            }
+        } else {
+            if (estimatedBytes <= segmentMaxLengthOriginal || !multiThreadedCompressionEnabled) {
+                Deflater deflater = new Deflater(compressionLevel);
+                DeflaterOutputStream deflaterOutputStream = new DeflaterOutputStream(idatChunksOutputStream, deflater);
+                PngEncoderScanlineUtil.stream(bufferedImage, 0, bufferedImage.getHeight(), new AbstractPNGLineConsumer() {
+                    @Override
+                    void consume(byte[] currRow, byte[] prevRow) throws IOException {
+                        deflaterOutputStream.write(currRow);
+                    }
+                });
+                deflaterOutputStream.finish();
+                deflaterOutputStream.flush();
+            } else {
+                PngEncoderDeflaterOutputStream deflaterOutputStream = new PngEncoderDeflaterOutputStream(
+                        idatChunksOutputStream, compressionLevel, segmentMaxLengthOriginal);
+                PngEncoderScanlineUtil.stream(bufferedImage, 0, bufferedImage.getHeight(), new AbstractPNGLineConsumer() {
+                    @Override
+                    void consume(byte[] currRow, byte[] prevRow) throws IOException {
+                        deflaterOutputStream.write(currRow);
+                    }
+                });
+                deflaterOutputStream.finish();
+            }
+        }
         countingOutputStream.write(FILE_ENDING);
 
         countingOutputStream.flush();
@@ -100,12 +135,75 @@ class PngEncoderLogic {
         return countingOutputStream.getCount();
     }
 
-    static byte[] getIhdrHeader(int width, int height, boolean alpha) {
+    private static byte[] getICCP(ICC_Profile colorProfile) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        // Write the profile name
+        String name = getProfileName(colorProfile);
+        byte[] nameBytes = name.getBytes(StandardCharsets.ISO_8859_1);
+        int nameByteWriteLen = Math.min(nameBytes.length, 79);
+        out.write(nameBytes, 0, nameByteWriteLen);
+        out.write(0);
+
+        // ZLib Compression
+        out.write(IHDR_COMPRESSION_METHOD);
+
+        // ICC Profile Data
+        try (DeflaterOutputStream compressStream = new DeflaterOutputStream(out)) {
+            compressStream.write(colorProfile.getData());
+        }
+        return out.toByteArray();
+    }
+
+    private static String getProfileName(ICC_Profile profile) {
+        byte[] data = profile.getData(ICC_Profile.icSigProfileDescriptionTag);
+        if (data == null) {
+            return "<noname>";
+        }
+        int startIdx = 12;
+        int endIdx = startIdx;
+        while (endIdx < data.length) {
+            int c = data[endIdx];
+            if (c == 0) {
+                break;
+            }
+            endIdx++;
+        }
+        if (endIdx != startIdx) {
+            return new String(data, startIdx, endIdx - startIdx, StandardCharsets.US_ASCII);
+        }
+
+        /*
+         * Unicode Format ... this is special to parse...
+         */
+        endIdx = startIdx = 29;
+        while (endIdx + 1 < data.length) {
+            int c = (data[endIdx] & 0xff) + (data[endIdx] & 0xFF);
+            if (c == 0) {
+                break;
+            }
+            endIdx += 2;
+        }
+        if (endIdx != startIdx) {
+            return new String(data, startIdx, endIdx - startIdx, StandardCharsets.UTF_16LE);
+        }
+        return "<unnamed>";
+    }
+
+
+    static byte[] getIhdrHeader(int width, int height, PngEncoderScanlineUtil.EncodingMetaInfo metaInfo) {
         ByteBuffer buffer = ByteBuffer.allocate(13);
         buffer.putInt(width);
         buffer.putInt(height);
-        buffer.put(IHDR_BIT_DEPTH);
-        buffer.put(alpha ? IHDR_COLOR_TYPE_RGBA : IHDR_COLOR_TYPE_RGB);
+        buffer.put((byte) metaInfo.bitsPerChannel);
+        switch (metaInfo.colorSpaceType) {
+            case Rgb:
+                buffer.put(metaInfo.hasAlpha ? IHDR_COLOR_TYPE_RGBA : IHDR_COLOR_TYPE_RGB);
+                break;
+            case Gray:
+                buffer.put(metaInfo.hasAlpha ? IHDR_COLOR_TYPE_GREY_ALPHA : IHDR_COLOR_TYPE_GREY);
+                break;
+        }
         buffer.put(IHDR_COMPRESSION_METHOD);
         buffer.put(IHDR_FILTER_METHOD);
         buffer.put(IHDR_INTERLACE_METHOD);

--- a/src/main/java/com/pngencoder/PngEncoderPredictor.java
+++ b/src/main/java/com/pngencoder/PngEncoderPredictor.java
@@ -1,0 +1,160 @@
+package com.pngencoder;
+
+import com.pngencoder.PngEncoderScanlineUtil.AbstractPNGLineConsumer;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+class PngEncoderPredictor {
+    private PngEncoderPredictor() {
+    }
+
+    static void encodeImageMultiThreaded(BufferedImage image, PngEncoderScanlineUtil.EncodingMetaInfo metaInfo, OutputStream out) throws IOException {
+
+        int height = image.getHeight();
+        int heightPerSlice = Math.max(10, PngEncoderDeflaterOutputStream.SEGMENT_MAX_LENGTH_ORIGINAL_MIN / metaInfo.rowByteSize) + 1;
+
+        /*
+         * Encode the image in slices, so that we can stream some image rows into the CPU cache, and then
+         * get them distributed to the ZIP threads without thrashing the cache to much.
+         */
+        ByteArrayOutputStream outBytes = new ByteArrayOutputStream(heightPerSlice * metaInfo.rowByteSize);
+        for (int y = 0; y < height; y += heightPerSlice) {
+            int heightToProcess = Math.min(heightPerSlice, height - y);
+            new PngEncoderPredictor().encodeImage(image, y, heightToProcess, metaInfo, outBytes);
+            outBytes.writeTo(out);
+            outBytes.reset();
+        }
+    }
+
+    static void encodeImageSingleThreaded(BufferedImage image, PngEncoderScanlineUtil.EncodingMetaInfo metaInfo, OutputStream outputStream) throws IOException {
+        new PngEncoderPredictor().encodeImage(image, 0, image.getHeight(), metaInfo, outputStream);
+    }
+
+    private byte[] dataRawRowSub;
+    private byte[] dataRawRowUp;
+    private byte[] dataRawRowAverage;
+    private byte[] dataRawRowPaeth;
+
+    private void encodeImage(BufferedImage image, int yStart, int height, PngEncoderScanlineUtil.EncodingMetaInfo metaInfo, OutputStream outputStream) throws IOException {
+        dataRawRowSub = new byte[metaInfo.rowByteSize];
+        dataRawRowUp = new byte[metaInfo.rowByteSize];
+        dataRawRowAverage = new byte[metaInfo.rowByteSize];
+        dataRawRowPaeth = new byte[metaInfo.rowByteSize];
+
+        dataRawRowSub[0] = 1;
+        dataRawRowUp[0] = 2;
+        dataRawRowAverage[0] = 3;
+        dataRawRowPaeth[0] = 4;
+
+        boolean redoFirstRow = yStart > 0;
+        PngEncoderScanlineUtil.stream(image, redoFirstRow ? (yStart - 1) : yStart, height + (redoFirstRow ? 1 : 0), new AbstractPNGLineConsumer() {
+            boolean skipFirstRow = redoFirstRow;
+
+            @Override
+            void consume(byte[] currRow, byte[] prevRow) throws IOException {
+                if (skipFirstRow) {
+                    skipFirstRow = false;
+                    return;
+                }
+
+                int bpp = metaInfo.bytesPerPixel;
+                @SuppressWarnings("UnnecessaryLocalVariable")
+                byte[] dataRawRowNone = currRow;
+                byte[] dataRawRowSub = PngEncoderPredictor.this.dataRawRowSub;
+                byte[] dataRawRowUp = PngEncoderPredictor.this.dataRawRowUp;
+                byte[] dataRawRowAverage = PngEncoderPredictor.this.dataRawRowAverage;
+                byte[] dataRawRowPaeth = PngEncoderPredictor.this.dataRawRowPaeth;
+
+                // c | b
+                // -----
+                // a | x
+                //
+                // x => current pixel
+                int bLen = currRow.length;
+                assert currRow.length == prevRow.length;
+                assert currRow[0] == 0;
+                assert prevRow[0] == 0;
+
+                long estCompressSum = 0;        // Marker 0 for no predictor
+                long estCompressSumSub = 1;     // Marker 1 for sub predictor
+                long estCompressSumUp = 2;      // Marker 2 for up preditor
+                long estCompressSumAvg = 3;     // Marker 3 for average predictor
+                long estCompressSumPaeth = 4;   // Marker 4 for paeth predictor
+
+                int a = 0;
+                int c = 0;
+                for (int i = 1; i < bLen; i++) {
+                    int x = currRow[i] & 0xFF;
+                    int b = prevRow[i] & 0xFF;
+                    if (i > bpp) {
+                        int prevPixelByte = i - bpp;
+                        a = currRow[prevPixelByte] & 0xFF;
+                        c = prevRow[prevPixelByte] & 0xFF;
+                    }
+
+                    /*
+                     * PNG Filters, see https://www.w3.org/TR/PNG-Filters.html
+                     */
+                    byte bSub = (byte) (x - a);
+                    byte bUp = (byte) (x - b);
+                    byte bAverage = (byte) (x - ((b + a) / 2));
+                    byte bPaeth;
+                    {
+                        int p = a + b - c;
+                        int pa = Math.abs(p - a);
+                        int pb = Math.abs(p - b);
+                        int pc = Math.abs(p - c);
+                        final int pr;
+                        if (pa <= pb && pa <= pc) {
+                            pr = a;
+                        } else if (pb <= pc) {
+                            pr = b;
+                        } else {
+                            pr = c;
+                        }
+
+                        int r = x - pr;
+                        bPaeth = (byte) r;
+                    }
+
+                    dataRawRowSub[i] = bSub;
+                    dataRawRowUp[i] = bUp;
+                    dataRawRowAverage[i] = bAverage;
+                    dataRawRowPaeth[i] = bPaeth;
+
+                    estCompressSum += Math.abs(x);
+                    estCompressSumSub += Math.abs(bSub);
+                    estCompressSumUp += Math.abs(bUp);
+                    estCompressSumAvg += Math.abs(bAverage);
+                    estCompressSumPaeth += Math.abs(bPaeth);
+                }
+
+                /*
+                 * Choose which row to write
+                 * https://www.w3.org/TR/PNG-Encoders.html#E.Filter-selection
+                 */
+                byte[] rowToWrite = dataRawRowNone;
+                if (estCompressSum > estCompressSumSub) {
+                    rowToWrite = dataRawRowSub;
+                    estCompressSum = estCompressSumSub;
+                }
+                if (estCompressSum > estCompressSumUp) {
+                    rowToWrite = dataRawRowUp;
+                    estCompressSum = estCompressSumUp;
+                }
+                if (estCompressSum > estCompressSumAvg) {
+                    rowToWrite = dataRawRowAverage;
+                    estCompressSum = estCompressSumAvg;
+                }
+                if (estCompressSum > estCompressSumPaeth) {
+                    rowToWrite = dataRawRowPaeth;
+                }
+
+                outputStream.write(rowToWrite);
+            }
+        });
+    }
+}

--- a/src/main/java/com/pngencoder/PngEncoderScanlineUtil.java
+++ b/src/main/java/com/pngencoder/PngEncoderScanlineUtil.java
@@ -1,172 +1,813 @@
 package com.pngencoder;
 
 import java.awt.Transparency;
+import java.awt.color.ColorSpace;
+import java.awt.color.ICC_ColorSpace;
+import java.awt.color.ICC_Profile;
 import java.awt.image.BufferedImage;
+import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferByte;
 import java.awt.image.DataBufferInt;
 import java.awt.image.DataBufferUShort;
+import java.awt.image.PixelInterleavedSampleModel;
+import java.awt.image.SampleModel;
+import java.awt.image.SinglePixelPackedSampleModel;
+import java.awt.image.WritableRaster;
+import java.io.IOException;
 
 class PngEncoderScanlineUtil {
     private PngEncoderScanlineUtil() {
     }
 
-    static byte[] get(BufferedImage bufferedImage) {
-        final int width = bufferedImage.getWidth();
+    /**
+     * Consumer for the image rows as bytes. Every row has the predictor marker as
+     * first byte (with 0 for no predictor encoding), after that all image bytes
+     * follow.
+     * <p>
+     * This is a class and not an interface for performance reasons. So that the JVM can
+     * fall back to simple vtable call in the polymorphic call site. As you can read on
+     * <a href="https://wiki.openjdk.java.net/display/HotSpot/InterfaceCalls">https://wiki.openjdk.java.net/display/HotSpot/InterfaceCalls</a>
+     * interface calls are very expensive and not suitable for performance critical sites, which can
+     * be polymorphic.
+     */
+    static abstract class AbstractPNGLineConsumer {
+        /**
+         * Consume and encode a row bytes consisting of image bytes.
+         *
+         * @param currRow the current row which should be encoded in the image stream
+         * @param prevRow the previous row, which is required for predictor encoding.
+         *                Is complete filled with 0 when encoding the first row.
+         * @throws IOException if some IO error happens
+         */
+        abstract void consume(byte[] currRow, byte[] prevRow) throws IOException;
+    }
+
+    /**
+     * Consumer getting everything as big byte array. Only used to implement get().
+     * <p>
+     * This thrashes the CPU cache, as with bigger images the whole image data will
+     * not fit into the cache and has to be fetched again from main memory when future
+     * processing the data.
+     */
+    static class ByteBufferPNGLineConsumer extends AbstractPNGLineConsumer {
+        byte[] bytes;
+        int currentOffset;
+
+        ByteBufferPNGLineConsumer(int byteCount) {
+            bytes = new byte[byteCount];
+        }
+
+        void consume(byte[] currRow, byte[] prevRow) {
+            System.arraycopy(currRow, 0, bytes, currentOffset, currRow.length);
+            currentOffset += currRow.length;
+        }
+    }
+
+    /**
+     * Metadata about how the image has to be encoded.
+     */
+    static class EncodingMetaInfo {
+        /**
+         * Count of color channels. Can either be 1 (for gray),
+         */
+        int channels;
+        /**
+         * Of how many bytes does a pixel have? This is needed for the predictor.
+         */
+        int bytesPerPixel;
+        /**
+         * Bits per channel, can be 8 or 16
+         */
+        int bitsPerChannel = 8;
+        /**
+         * Size of a row consumed by AbstractPNGLineConsumer::consume() including a
+         * 1 byte marker for the predictor.
+         */
+        int rowByteSize;
+        /**
+         * Do we have a alpha channel?
+         */
+        boolean hasAlpha;
+        /**
+         * If not null we must embed this color profile in the PNG file.
+         * It can only be null for sRGB images.
+         */
+        ICC_Profile colorProfile;
+
+        enum ColorSpaceType {
+            Rgb,
+            Gray
+        }
+
+        /**
+         * The kind of color space used in the image
+         */
+        ColorSpaceType colorSpaceType = ColorSpaceType.Rgb;
+    }
+
+    /*
+     * Get the encoding metadata
+     */
+    static EncodingMetaInfo getEncodingMetaInfo(BufferedImage bufferedImage) {
+        EncodingMetaInfo info = new EncodingMetaInfo();
+        int width = bufferedImage.getWidth();
+        final PngEncoderBufferedImageType type = PngEncoderBufferedImageType.valueOf(bufferedImage);
+        ColorSpace colorSpace = bufferedImage.getColorModel().getColorSpace();
+
+        boolean needToFallBackTosRGB = false;
+        if (!colorSpace.isCS_sRGB() && colorSpace instanceof ICC_ColorSpace) {
+            info.colorProfile = ((ICC_ColorSpace) colorSpace).getProfile();
+            switch (colorSpace.getType()) {
+                case ColorSpace.TYPE_RGB:
+                    break;
+                case ColorSpace.TYPE_GRAY:
+                    info.colorSpaceType = EncodingMetaInfo.ColorSpaceType.Gray;
+                    break;
+                default:
+                    /*
+                     * We can only handle RGB and GRAY in png. CMYK etc. is not in the
+                     * spec...
+                     */
+                    needToFallBackTosRGB = true;
+                    break;
+            }
+        }
+
+        switch (type) {
+            case TYPE_INT_ARGB:
+            case TYPE_INT_ARGB_PRE:
+            case TYPE_4BYTE_ABGR:
+            case TYPE_4BYTE_ABGR_PRE:
+                info.channels = 4;
+                info.bytesPerPixel = 4;
+                info.hasAlpha = true;
+                break;
+            case TYPE_INT_BGR:
+            case TYPE_3BYTE_BGR:
+            case TYPE_USHORT_565_RGB:
+            case TYPE_USHORT_555_RGB:
+            case TYPE_INT_RGB:
+                info.channels = 3;
+                info.bytesPerPixel = 3;
+                break;
+            case TYPE_BYTE_GRAY:
+                info.channels = 1;
+                info.bytesPerPixel = 1;
+                break;
+            case TYPE_USHORT_GRAY:
+                info.channels = 1;
+                info.bytesPerPixel = 2;
+                info.bitsPerChannel = 16;
+                break;
+            default:
+                boolean canICCBeHandled = false;
+                SampleModel sampleModel = bufferedImage.getRaster().getSampleModel();
+                info.hasAlpha = bufferedImage.getTransparency() != Transparency.OPAQUE;
+
+                /*
+                 * Default sRGB byte encoding
+                 */
+                if (!info.hasAlpha) {
+                    info.channels = 3;
+                    info.bytesPerPixel = 3;
+                } else {
+                    info.channels = 4;
+                    info.bytesPerPixel = 4;
+                }
+
+                /*
+                 * When it is a UShort GRAY or RGB buffer we can write it as 16 bit image.
+                 */
+                if (!needToFallBackTosRGB && bufferedImage.getRaster().getDataBuffer().getDataType() == DataBuffer.TYPE_USHORT) {
+                    info.channels = sampleModel.getNumBands();
+                    info.bytesPerPixel = info.channels * 2;
+                    info.bitsPerChannel = 16;
+                    canICCBeHandled = true;
+                }
+                /*
+                 * Custom Int Buffers storing 8 bit RGB
+                 */
+                if (!needToFallBackTosRGB && bufferedImage.getRaster().getDataBuffer().getDataType() == DataBuffer.TYPE_INT
+                        && bufferedImage.getSampleModel().getSampleSize(0) == 8) {
+                    canICCBeHandled = true;
+                }
+
+                /*
+                 * When we can not handle the data buffer we have to fall back to sRGB. So we should not include a color profile
+                 */
+                if (!canICCBeHandled) {
+                    info.colorProfile = null;
+                }
+                break;
+        }
+
+        info.rowByteSize = 1 + info.bytesPerPixel * width;
+        return info;
+    }
+
+    static byte[] get(BufferedImage bufferedImage) throws IOException {
         final int height = bufferedImage.getHeight();
+        EncodingMetaInfo encodingMetaInfo = getEncodingMetaInfo(bufferedImage);
+        ByteBufferPNGLineConsumer consumer = new ByteBufferPNGLineConsumer(encodingMetaInfo.rowByteSize * height);
+        stream(bufferedImage, 0, height, consumer);
+        return consumer.bytes;
+    }
+
+    /**
+     * Stream image rows to a consumer, row by row.
+     */
+    static void stream(BufferedImage bufferedImage, int yStart, int heightToStream, AbstractPNGLineConsumer consumer)
+            throws IOException {
+        final int width = bufferedImage.getWidth();
+        final int imageHeight = bufferedImage.getHeight();
+        assert (heightToStream <= imageHeight - yStart);
 
         final PngEncoderBufferedImageType type = PngEncoderBufferedImageType.valueOf(bufferedImage);
 
-        if (type == PngEncoderBufferedImageType.TYPE_INT_RGB) {
-            final int[] elements = ((DataBufferInt) bufferedImage.getRaster().getDataBuffer()).getData();
-            return getIntRgb(elements, width, height);
+        WritableRaster raster = bufferedImage.getRaster();
+        switch (type) {
+            case TYPE_INT_RGB:
+                getIntRgb(raster, yStart, width, heightToStream, consumer);
+                break;
+            case TYPE_INT_ARGB:
+                getIntArgb(raster, yStart, width, heightToStream, consumer);
+                break;
+
+            // TODO: TYPE_INT_ARGB_PRE
+            case TYPE_INT_BGR:
+                getIntBgr(raster, yStart, width, heightToStream, consumer);
+                break;
+            case TYPE_3BYTE_BGR:
+                get3ByteBgr(raster, yStart, width, heightToStream, consumer);
+                break;
+            case TYPE_4BYTE_ABGR:
+                get4ByteAbgr(raster, yStart, width, heightToStream, consumer);
+                break;
+            // TODO: TYPE_4BYTE_ABGR_PRE
+            // TODO: TYPE_USHORT_565_RGB
+            // TODO: TYPE_USHORT_555_RGB
+            case TYPE_BYTE_GRAY:
+                getByteGray(bufferedImage, yStart, width, heightToStream, consumer);
+                break;
+            case TYPE_USHORT_GRAY:
+                getUshortGray(bufferedImage, yStart, width, heightToStream, consumer);
+                break;
+            default:
+                if (raster.getDataBuffer() instanceof DataBufferUShort) {
+                    if (getUshortGenericDataBufferUShort(bufferedImage, yStart, width, heightToStream, consumer)) {
+                        break;
+                    }
+                }
+                // Generic DataBuffer variants.
+                if (raster.getDataBuffer().getDataType() == DataBuffer.TYPE_USHORT) {
+                    if (getUshortGeneric(bufferedImage, yStart, width, heightToStream, consumer)) {
+                        break;
+                    }
+                }
+                if (raster.getDataBuffer().getDataType() == DataBuffer.TYPE_BYTE) {
+                    if (getByteGeneric(bufferedImage, yStart, width, heightToStream, consumer)) {
+                        break;
+                    }
+                }
+                if (raster.getDataBuffer().getDataType() == DataBuffer.TYPE_INT) {
+                    if (getIntGeneric(bufferedImage, yStart, width, heightToStream, consumer)) {
+                        break;
+                    }
+                }
+
+                // Fallback for unsupported type.
+                final int[] elements = bufferedImage.getRGB(0, yStart, width, heightToStream, null, 0, width);
+                if (bufferedImage.getTransparency() == Transparency.OPAQUE) {
+                    getIntRgb(elements, yStart, width, heightToStream, consumer);
+                } else {
+                    getIntArgb(elements, yStart, width, heightToStream, consumer);
+                }
+                break;
         }
+    }
 
-        if (type == PngEncoderBufferedImageType.TYPE_INT_ARGB) {
-            final int[] elements = ((DataBufferInt) bufferedImage.getRaster().getDataBuffer()).getData();
-            return getIntArgb(elements, width, height);
+    static void getIntRgb(int[] elements, int yStart, int width, int height, AbstractPNGLineConsumer consumer)
+            throws IOException {
+        final int channels = 3;
+        final int rowByteSize = 1 + channels * width;
+        byte[] currLine = new byte[rowByteSize];
+        byte[] prevLine = new byte[rowByteSize];
+
+        for (int y = yStart; y < yStart + height; y++) {
+            int yOffset = y * width;
+
+            int rowByteOffset = 1;
+
+            for (int x = 0; x < width; x++) {
+                final int element = elements[yOffset + x];
+                currLine[rowByteOffset++] = (byte) (element >> 16); // R
+                currLine[rowByteOffset++] = (byte) (element >> 8); // G
+                currLine[rowByteOffset++] = (byte) element; // B
+            }
+            consumer.consume(currLine, prevLine);
+            {
+                byte[] b = currLine;
+                currLine = prevLine;
+                prevLine = b;
+            }
         }
+    }
 
-        // TODO: TYPE_INT_ARGB_PRE
+    static void getIntArgb(int[] elements, int yStart, int width, int height, AbstractPNGLineConsumer consumer)
+            throws IOException {
+        final int channels = 4;
+        final int rowByteSize = 1 + channels * width;
+        byte[] currLine = new byte[rowByteSize];
+        byte[] prevLine = new byte[rowByteSize];
 
-        if (type == PngEncoderBufferedImageType.TYPE_INT_BGR) {
-            final int[] elements = ((DataBufferInt) bufferedImage.getRaster().getDataBuffer()).getData();
-            return getIntBgr(elements, width, height);
+        for (int y = yStart; y < yStart + height; y++) {
+            int yOffset = y * width;
+
+            int rowByteOffset = 1;
+            for (int x = 0; x < width; x++) {
+                final int element = elements[yOffset + x];
+                currLine[rowByteOffset++] = (byte) (element >> 16); // R
+                currLine[rowByteOffset++] = (byte) (element >> 8); // G
+                currLine[rowByteOffset++] = (byte) element; // B
+                currLine[rowByteOffset++] = (byte) (element >> 24); // A
+            }
+            consumer.consume(currLine, prevLine);
+            {
+                byte[] b = currLine;
+                currLine = prevLine;
+                prevLine = b;
+            }
         }
+    }
 
-        if (type == PngEncoderBufferedImageType.TYPE_3BYTE_BGR) {
-            final byte[] elements = ((DataBufferByte) bufferedImage.getRaster().getDataBuffer()).getData();
-            return get3ByteBgr(elements, width, height);
-        }
+    static void getIntRgb(WritableRaster imageRaster, int yStart, int width, int heightToStream,
+            AbstractPNGLineConsumer consumer) throws IOException {
+        final int channels = 3;
+        final int rowByteSize = 1 + channels * width;
+        byte[] currLine = new byte[rowByteSize];
+        byte[] prevLine = new byte[rowByteSize];
 
-        if (type == PngEncoderBufferedImageType.TYPE_4BYTE_ABGR) {
-            final byte[] elements = ((DataBufferByte) bufferedImage.getRaster().getDataBuffer()).getData();
-            return get4ByteAbgr(elements, width, height);
-        }
+        if (imageRaster.getSampleModel() instanceof SinglePixelPackedSampleModel) {
+            SinglePixelPackedSampleModel sampleModel = (SinglePixelPackedSampleModel) imageRaster.getSampleModel();
+            int scanlineStride = sampleModel.getScanlineStride();
+            assert sampleModel.getNumBands() == 3;
+            assert sampleModel.getBitOffsets()[0] == 16;
+            assert sampleModel.getBitOffsets()[1] == 8;
+            assert sampleModel.getBitOffsets()[2] == 0;
+            int[] rawInts = ((DataBufferInt) imageRaster.getDataBuffer()).getData();
 
-        // TODO: TYPE_4BYTE_ABGR_PRE
+            int linePtr = scanlineStride * (yStart - imageRaster.getSampleModelTranslateY())
+                    - imageRaster.getSampleModelTranslateX();
+            for (int y = 0; y < heightToStream; y++) {
+                int pixelPtr = linePtr;
+                int pixelEndPtr = linePtr + width;
 
-        // TODO: TYPE_USHORT_565_RGB
-        // TODO: TYPE_USHORT_555_RGB
+                int rowByteOffset = 1;
+                while (pixelPtr < pixelEndPtr) {
+                    final int element = rawInts[pixelPtr++];
+                    currLine[rowByteOffset++] = (byte) (element >> 16); // R
+                    currLine[rowByteOffset++] = (byte) (element >> 8); // G
+                    currLine[rowByteOffset++] = (byte) element; // B
+                }
 
-        if (type == PngEncoderBufferedImageType.TYPE_BYTE_GRAY) {
-            final byte[] elements = ((DataBufferByte) bufferedImage.getRaster().getDataBuffer()).getData();
-            return getByteGray(elements, width, height);
-        }
+                linePtr += scanlineStride;
+                consumer.consume(currLine, prevLine);
 
-        if (type == PngEncoderBufferedImageType.TYPE_USHORT_GRAY) {
-            final short[] elements = ((DataBufferUShort) bufferedImage.getRaster().getDataBuffer()).getData();
-            return getUshortGray(elements, width, height);
-        }
-
-        // Fallback for unsupported type.
-        final int[] elements = bufferedImage.getRGB(0, 0, width, height, null, 0, width);
-        if (bufferedImage.getTransparency() == Transparency.OPAQUE) {
-            return getIntRgb(elements, width, height);
+                {
+                    byte[] b = currLine;
+                    currLine = prevLine;
+                    prevLine = b;
+                }
+            }
         } else {
-            return getIntArgb(elements, width, height);
+            throw new IllegalStateException("TYPE_INT_RGB must have a SinglePixelPackedSampleModel");
         }
     }
 
-    static byte[] getIntRgb(int[] elements, int width, int height) {
-        final int channels = 3;
-        final int rowByteSize = 1 + channels*width;
-        final byte[] bytes = new byte[rowByteSize * height];
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                final int element = elements[y*width + x];
-                bytes[y*rowByteSize + x*channels + 1] = (byte) (element >> 16); // R
-                bytes[y*rowByteSize + x*channels + 2] = (byte) (element >> 8);  // G
-                bytes[y*rowByteSize + x*channels + 3] = (byte) (element);       // B
-            }
-        }
-        return bytes;
-    }
-
-    static byte[] getIntArgb(int[] elements, int width, int height) {
+    static void getIntArgb(WritableRaster imageRaster, int yStart, int width, int heightToStream,
+            AbstractPNGLineConsumer consumer) throws IOException {
         final int channels = 4;
-        final int rowByteSize = 1 + channels*width;
-        final byte[] bytes = new byte[rowByteSize * height];
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                final int element = elements[y*width + x];
-                bytes[y*rowByteSize + x*channels + 1] = (byte) (element >> 16); // R
-                bytes[y*rowByteSize + x*channels + 2] = (byte) (element >> 8);  // G
-                bytes[y*rowByteSize + x*channels + 3] = (byte) (element);       // B
-                bytes[y*rowByteSize + x*channels + 4] = (byte) (element >> 24); // A
+        final int rowByteSize = 1 + channels * width;
+        byte[] currLine = new byte[rowByteSize];
+        byte[] prevLine = new byte[rowByteSize];
+
+        if (imageRaster.getSampleModel() instanceof SinglePixelPackedSampleModel) {
+            SinglePixelPackedSampleModel sampleModel = (SinglePixelPackedSampleModel) imageRaster.getSampleModel();
+            int scanlineStride = sampleModel.getScanlineStride();
+            assert sampleModel.getNumBands() == 4;
+            assert sampleModel.getBitOffsets()[0] == 16;
+            assert sampleModel.getBitOffsets()[1] == 8;
+            assert sampleModel.getBitOffsets()[2] == 0;
+            assert sampleModel.getBitOffsets()[3] == 24;
+            int[] rawInts = ((DataBufferInt) imageRaster.getDataBuffer()).getData();
+
+            int linePtr = scanlineStride * (yStart - imageRaster.getSampleModelTranslateY())
+                    - imageRaster.getSampleModelTranslateX();
+
+            for (int y = 0; y < heightToStream; y++) {
+                int pixelPtr = linePtr;
+
+                int rowByteOffset = 1;
+                for (int x = 0; x < width; x++) {
+                    final int element = rawInts[pixelPtr++];
+                    currLine[rowByteOffset++] = (byte) (element >> 16); // R
+                    currLine[rowByteOffset++] = (byte) (element >> 8); // G
+                    currLine[rowByteOffset++] = (byte) element; // B
+                    currLine[rowByteOffset++] = (byte) (element >> 24); // A
+                }
+
+                linePtr += scanlineStride;
+                consumer.consume(currLine, prevLine);
+
+                {
+                    byte[] b = currLine;
+                    currLine = prevLine;
+                    prevLine = b;
+                }
             }
+        } else {
+            throw new IllegalStateException("TYPE_INT_RGB must have a SinglePixelPackedSampleModel");
         }
-        return bytes;
     }
 
-    static byte[] getIntBgr(int[] elements, int width, int height) {
+    static void getIntBgr(WritableRaster imageRaster, int yStart, int width, int heightToStream,
+            AbstractPNGLineConsumer consumer) throws IOException {
         final int channels = 3;
-        final int rowByteSize = 1 + channels*width;
-        final byte[] bytes = new byte[rowByteSize * height];
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                final int element = elements[y*width + x];
-                bytes[y*rowByteSize + x*channels + 1] = (byte) (element);       // R
-                bytes[y*rowByteSize + x*channels + 2] = (byte) (element >> 8);  // G
-                bytes[y*rowByteSize + x*channels + 3] = (byte) (element >> 16); // B
+        final int rowByteSize = 1 + channels * width;
+        byte[] currLine = new byte[rowByteSize];
+        byte[] prevLine = new byte[rowByteSize];
+
+        if (imageRaster.getSampleModel() instanceof SinglePixelPackedSampleModel) {
+            SinglePixelPackedSampleModel sampleModel = (SinglePixelPackedSampleModel) imageRaster.getSampleModel();
+            int scanlineStride = sampleModel.getScanlineStride();
+            assert sampleModel.getNumBands() == 3;
+            assert sampleModel.getBitOffsets()[0] == 0;
+            assert sampleModel.getBitOffsets()[1] == 8;
+            assert sampleModel.getBitOffsets()[2] == 16;
+            int[] rawInts = ((DataBufferInt) imageRaster.getDataBuffer()).getData();
+
+            int linePtr = scanlineStride * (yStart - imageRaster.getSampleModelTranslateY())
+                    - imageRaster.getSampleModelTranslateX();
+            for (int y = 0; y < heightToStream; y++) {
+                int pixelPtr = linePtr;
+
+                int rowByteOffset = 1;
+                for (int x = 0; x < width; x++) {
+                    final int element = rawInts[pixelPtr++];
+                    currLine[rowByteOffset++] = (byte) element; // R
+                    currLine[rowByteOffset++] = (byte) (element >> 8); // G
+                    currLine[rowByteOffset++] = (byte) (element >> 16); // B
+                }
+
+                linePtr += scanlineStride;
+                consumer.consume(currLine, prevLine);
+
+                {
+                    byte[] b = currLine;
+                    currLine = prevLine;
+                    prevLine = b;
+                }
             }
+        } else {
+            throw new IllegalStateException("TYPE_INT_BGR must have a SinglePixelPackedSampleModel");
         }
-        return bytes;
     }
 
-    static byte[] get3ByteBgr(byte[] elements, int width, int height) {
+    static void get3ByteBgr(WritableRaster imageRaster, int yStart, int width, int heightToStream,
+            AbstractPNGLineConsumer consumer) throws IOException {
         final int channels = 3;
-        final int rowByteSize = 1 + channels*width;
-        final byte[] bytes = new byte[rowByteSize * height];
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                bytes[y*rowByteSize + x*channels + 1] = elements[(y*width + x)*3 + 2]; // R
-                bytes[y*rowByteSize + x*channels + 2] = elements[(y*width + x)*3 + 1]; // G
-                bytes[y*rowByteSize + x*channels + 3] = elements[(y*width + x)*3 + 0]; // B
+        final int rowByteSize = 1 + channels * width;
+        byte[] currLine = new byte[rowByteSize];
+        byte[] prevLine = new byte[rowByteSize];
+        DataBufferByte dataBufferByte = (DataBufferByte) imageRaster.getDataBuffer();
+        if (imageRaster.getSampleModel() instanceof PixelInterleavedSampleModel) {
+            PixelInterleavedSampleModel sampleModel = (PixelInterleavedSampleModel) imageRaster.getSampleModel();
+            byte[] rawBytes = dataBufferByte.getData();
+            int scanlineStride = sampleModel.getScanlineStride();
+            int pixelStride = sampleModel.getPixelStride();
+
+            assert pixelStride == 3;
+            int linePtr = scanlineStride * (yStart - imageRaster.getSampleModelTranslateY())
+                    - imageRaster.getSampleModelTranslateX() * pixelStride;
+
+            for (int y = 0; y < heightToStream; y++) {
+                int pixelPtr = linePtr;
+                int writePtr = 1;
+                for (int x = 0; x < width; x++) {
+                    byte b = rawBytes[pixelPtr++];
+                    byte g = rawBytes[pixelPtr++];
+                    byte r = rawBytes[pixelPtr++];
+                    currLine[writePtr++] = r;
+                    currLine[writePtr++] = g;
+                    currLine[writePtr++] = b;
+                }
+                linePtr += scanlineStride;
+                consumer.consume(currLine, prevLine);
+                {
+                    byte[] b = currLine;
+                    currLine = prevLine;
+                    prevLine = b;
+                }
             }
+        } else {
+            throw new IllegalStateException("3ByteBgr must have a PixelInterleavedSampleModel");
         }
-        return bytes;
     }
 
-    static byte[] get4ByteAbgr(byte[] elements, int width, int height) {
+    static void get4ByteAbgr(WritableRaster imageRaster, int yStart, int width, int heightToStream,
+            AbstractPNGLineConsumer consumer) throws IOException {
         final int channels = 4;
-        final int rowByteSize = 1 + channels*width;
-        final byte[] bytes = new byte[rowByteSize * height];
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                bytes[y*rowByteSize + x*channels + 1] = elements[(y*width + x)*4 + 3]; // R
-                bytes[y*rowByteSize + x*channels + 2] = elements[(y*width + x)*4 + 2]; // G
-                bytes[y*rowByteSize + x*channels + 3] = elements[(y*width + x)*4 + 1]; // B
-                bytes[y*rowByteSize + x*channels + 4] = elements[(y*width + x)*4];     // A
+        final int rowByteSize = 1 + channels * width;
+        byte[] currLine = new byte[rowByteSize];
+        byte[] prevLine = new byte[rowByteSize];
+        DataBufferByte dataBufferByte = (DataBufferByte) imageRaster.getDataBuffer();
+        if (imageRaster.getSampleModel() instanceof PixelInterleavedSampleModel) {
+            PixelInterleavedSampleModel sampleModel = (PixelInterleavedSampleModel) imageRaster.getSampleModel();
+            byte[] rawBytes = dataBufferByte.getData();
+            int scanlineStride = sampleModel.getScanlineStride();
+            int pixelStride = sampleModel.getPixelStride();
+
+            assert pixelStride == 4;
+            int linePtr = scanlineStride * (yStart - imageRaster.getSampleModelTranslateY())
+                    - imageRaster.getSampleModelTranslateX() * pixelStride;
+            for (int y = 0; y < heightToStream; y++) {
+                int pixelPtr = linePtr;
+                int writePtr = 1;
+                for (int x = 0; x < width; x++) {
+                    byte a = rawBytes[pixelPtr++];
+                    byte b = rawBytes[pixelPtr++];
+                    byte g = rawBytes[pixelPtr++];
+                    byte r = rawBytes[pixelPtr++];
+                    currLine[writePtr++] = r;
+                    currLine[writePtr++] = g;
+                    currLine[writePtr++] = b;
+                    currLine[writePtr++] = a;
+                }
+                linePtr += scanlineStride;
+                consumer.consume(currLine, prevLine);
+                {
+                    byte[] b = currLine;
+                    currLine = prevLine;
+                    prevLine = b;
+                }
             }
+        } else {
+            throw new IllegalStateException("4ByteAbgr must have a PixelInterleavedSampleModel");
         }
-        return bytes;
     }
 
-    static byte[] getByteGray(byte[] elements, int width, int height) {
-        final int channels = 3;
-        final int rowByteSize = 1 + channels*width;
-        final byte[] bytes = new byte[rowByteSize * height];
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                bytes[y*rowByteSize + x*channels + 1] = elements[(y*width + x)]; // R
-                bytes[y*rowByteSize + x*channels + 2] = elements[(y*width + x)]; // G
-                bytes[y*rowByteSize + x*channels + 3] = elements[(y*width + x)]; // B
+    static void getByteGray(BufferedImage image, int yStart, int width, int heightToStream, AbstractPNGLineConsumer consumer)
+            throws IOException {
+        WritableRaster imageRaster = image.getRaster();
+
+        final int channels = 1;
+        final int rowByteSize = 1 + channels * width;
+        byte[] currLine = new byte[rowByteSize];
+        byte[] prevLine = new byte[rowByteSize];
+
+        DataBufferByte dataBufferByte = (DataBufferByte) imageRaster.getDataBuffer();
+        if (imageRaster.getSampleModel() instanceof PixelInterleavedSampleModel) {
+            PixelInterleavedSampleModel sampleModel = (PixelInterleavedSampleModel) imageRaster.getSampleModel();
+            byte[] rawBytes = dataBufferByte.getData();
+            int scanlineStride = sampleModel.getScanlineStride();
+            int pixelStride = sampleModel.getPixelStride();
+
+            assert pixelStride == 1;
+            int linePtr = scanlineStride * (yStart - imageRaster.getSampleModelTranslateY())
+                    - imageRaster.getSampleModelTranslateX() * pixelStride;
+            for (int y = 0; y < heightToStream; y++) {
+                int pixelPtr = linePtr;
+
+                System.arraycopy(rawBytes, pixelPtr, currLine, 1, width);
+
+                linePtr += scanlineStride;
+                consumer.consume(currLine, prevLine);
+                {
+                    byte[] b = currLine;
+                    currLine = prevLine;
+                    prevLine = b;
+                }
             }
+        } else {
+            throw new IllegalStateException("TYPE_BYTE_GRAY must have a PixelInterleavedSampleModel");
         }
-        return bytes;
     }
 
-    static byte[] getUshortGray(short[] elements, int width, int height) {
-        final int channels = 3;
-        final int rowByteSize = 1 + channels*width;
-        final byte[] bytes = new byte[rowByteSize * height];
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                bytes[y*rowByteSize + x*channels + 1] = (byte) (elements[(y*width + x)] >> 8); // R
-                bytes[y*rowByteSize + x*channels + 2] = (byte) (elements[(y*width + x)] >> 8); // G
-                bytes[y*rowByteSize + x*channels + 3] = (byte) (elements[(y*width + x)] >> 8); // B
+    static void getUshortGray(BufferedImage image, int yStart, int width, int heightToStream, AbstractPNGLineConsumer consumer)
+            throws IOException {
+        WritableRaster imageRaster = image.getRaster();
+
+        final int channels = 1;
+        final int rowByteSize = 1 + channels * width * 2;
+        byte[] currLine = new byte[rowByteSize];
+        byte[] prevLine = new byte[rowByteSize];
+
+        DataBufferUShort dataBufferUShort = (DataBufferUShort) imageRaster.getDataBuffer();
+        if (imageRaster.getSampleModel() instanceof PixelInterleavedSampleModel) {
+            PixelInterleavedSampleModel sampleModel = (PixelInterleavedSampleModel) imageRaster.getSampleModel();
+            short[] rawShorts = dataBufferUShort.getData();
+            int scanlineStride = sampleModel.getScanlineStride();
+            int pixelStride = sampleModel.getPixelStride();
+
+            assert pixelStride == 1;
+            int linePtr = scanlineStride * (yStart - imageRaster.getSampleModelTranslateY())
+                    - imageRaster.getSampleModelTranslateX() * pixelStride;
+            for (int y = 0; y < heightToStream; y++) {
+                int pixelPtr = linePtr;
+                int writePtr = 1;
+                for (int x = 0; x < width; x++) {
+                    short grayColorValue = rawShorts[pixelPtr++];
+                    byte high = (byte) (grayColorValue >> 8);
+                    byte low = (byte) (grayColorValue & 0xff);
+                    currLine[writePtr++] = high;
+                    currLine[writePtr++] = low;
+                }
+                linePtr += scanlineStride;
+                consumer.consume(currLine, prevLine);
+                {
+                    byte[] b = currLine;
+                    currLine = prevLine;
+                    prevLine = b;
+                }
             }
+        } else {
+            throw new IllegalStateException("TYPE_USHORT_GRAY must have a PixelInterleavedSampleModel");
         }
-        return bytes;
+    }
+
+
+    static boolean getUshortGenericDataBufferUShort(BufferedImage image, int yStart, int width, int heightToStream, AbstractPNGLineConsumer consumer)
+            throws IOException {
+        WritableRaster imageRaster = image.getRaster();
+
+        DataBufferUShort dataBufferUShort = (DataBufferUShort) imageRaster.getDataBuffer();
+        final int channels = imageRaster.getSampleModel().getNumBands();
+        final int rowByteSize = 1 + channels * width * 2;
+        byte[] currLine = new byte[rowByteSize];
+        byte[] prevLine = new byte[rowByteSize];
+
+        if (imageRaster.getSampleModel() instanceof PixelInterleavedSampleModel) {
+            PixelInterleavedSampleModel sampleModel = (PixelInterleavedSampleModel) imageRaster.getSampleModel();
+            short[] rawShorts = dataBufferUShort.getData();
+            int scanlineStride = sampleModel.getScanlineStride();
+            int pixelStride = sampleModel.getPixelStride();
+            assert pixelStride == channels;
+
+            int linePtr = scanlineStride * (yStart - imageRaster.getSampleModelTranslateY())
+                    - imageRaster.getSampleModelTranslateX() * pixelStride;
+            for (int y = 0; y < heightToStream; y++) {
+                int pixelPtr = linePtr;
+                int writePtr = 1;
+                for (int x = 0; x < width; x++) {
+                    for (int inPixelPtr = 0; inPixelPtr < channels; inPixelPtr++) {
+                        short colorValue = rawShorts[pixelPtr++];
+                        byte high = (byte) (colorValue >> 8);
+                        byte low = (byte) (colorValue & 0xff);
+                        currLine[writePtr++] = high;
+                        currLine[writePtr++] = low;
+                    }
+                }
+                linePtr += scanlineStride;
+                consumer.consume(currLine, prevLine);
+                {
+                    byte[] b = currLine;
+                    currLine = prevLine;
+                    prevLine = b;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    static boolean getUshortGeneric(BufferedImage image, int yStart, int width, int heightToStream, AbstractPNGLineConsumer consumer)
+            throws IOException {
+        WritableRaster imageRaster = image.getRaster();
+
+        final int channels = imageRaster.getSampleModel().getNumBands();
+        final int rowByteSize = 1 + channels * width * 2;
+        byte[] currLine = new byte[rowByteSize];
+        byte[] prevLine = new byte[rowByteSize];
+
+        if (imageRaster.getSampleModel() instanceof PixelInterleavedSampleModel) {
+            PixelInterleavedSampleModel sampleModel = (PixelInterleavedSampleModel) imageRaster.getSampleModel();
+            DataBuffer dataBuffer = imageRaster.getDataBuffer();
+            int numBanks = dataBuffer.getNumBanks();
+            int scanlineStride = sampleModel.getScanlineStride();
+            int pixelStride = sampleModel.getPixelStride();
+            assert pixelStride == channels;
+            assert numBanks == 1;
+
+            int linePtr = scanlineStride * (yStart - imageRaster.getSampleModelTranslateY())
+                    - imageRaster.getSampleModelTranslateX() * pixelStride;
+            for (int y = 0; y < heightToStream; y++) {
+                int pixelPtr = linePtr;
+                int writePtr = 1;
+                for (int x = 0; x < width; x++) {
+                    for (int bankNum = 0; bankNum < channels; bankNum++) {
+                        short colorValue = (short) (dataBuffer.getElem(pixelPtr++) & 0xFFFF);
+                        byte high = (byte) (colorValue >> 8);
+                        byte low = (byte) (colorValue & 0xff);
+                        currLine[writePtr++] = high;
+                        currLine[writePtr++] = low;
+                    }
+                }
+                linePtr += scanlineStride;
+                consumer.consume(currLine, prevLine);
+                {
+                    byte[] b = currLine;
+                    currLine = prevLine;
+                    prevLine = b;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    static boolean getByteGeneric(BufferedImage image, int yStart, int width, int heightToStream, AbstractPNGLineConsumer consumer)
+            throws IOException {
+        WritableRaster imageRaster = image.getRaster();
+
+        final int channels = imageRaster.getSampleModel().getNumBands();
+        final int rowByteSize = 1 + channels * width;
+        byte[] currLine = new byte[rowByteSize];
+        byte[] prevLine = new byte[rowByteSize];
+
+        if (imageRaster.getSampleModel() instanceof PixelInterleavedSampleModel) {
+            PixelInterleavedSampleModel sampleModel = (PixelInterleavedSampleModel) imageRaster.getSampleModel();
+            DataBuffer dataBuffer = imageRaster.getDataBuffer();
+            int numBanks = dataBuffer.getNumBanks();
+            int scanlineStride = sampleModel.getScanlineStride();
+            int pixelStride = sampleModel.getPixelStride();
+            assert pixelStride == channels;
+            assert numBanks == 1;
+
+            int linePtr = scanlineStride * (yStart - imageRaster.getSampleModelTranslateY())
+                    - imageRaster.getSampleModelTranslateX() * pixelStride;
+            for (int y = 0; y < heightToStream; y++) {
+                int pixelPtr = linePtr;
+                int writePtr = 1;
+                for (int x = 0; x < width; x++) {
+                    for (int bankNum = 0; bankNum < channels; bankNum++) {
+                        byte colorValue = (byte) (dataBuffer.getElem(pixelPtr++) & 0xFF);
+                        currLine[writePtr++] = colorValue;
+                    }
+                }
+                linePtr += scanlineStride;
+                consumer.consume(currLine, prevLine);
+                {
+                    byte[] b = currLine;
+                    currLine = prevLine;
+                    prevLine = b;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+
+    static boolean getIntGeneric(BufferedImage image, int yStart, int width, int heightToStream, AbstractPNGLineConsumer consumer)
+            throws IOException {
+        WritableRaster imageRaster = image.getRaster();
+
+        final int channels = imageRaster.getSampleModel().getNumBands();
+        final int rowByteSize = 1 + channels * width;
+        byte[] currLine = new byte[rowByteSize];
+        byte[] prevLine = new byte[rowByteSize];
+
+        if (imageRaster.getSampleModel() instanceof SinglePixelPackedSampleModel) {
+            SinglePixelPackedSampleModel sampleModel = (SinglePixelPackedSampleModel) imageRaster.getSampleModel();
+            DataBuffer dataBuffer = imageRaster.getDataBuffer();
+            int numBanks = dataBuffer.getNumBanks();
+            int scanlineStride = sampleModel.getScanlineStride();
+            int[] bitOffsets = sampleModel.getBitOffsets();
+            int[] bitMasks = sampleModel.getBitMasks();
+            assert numBanks == 1;
+
+            int linePtr = scanlineStride * (yStart - imageRaster.getSampleModelTranslateY())
+                    - imageRaster.getSampleModelTranslateX();
+            for (int y = 0; y < heightToStream; y++) {
+                int pixelPtr = linePtr;
+                int writePtr = 1;
+                for (int x = 0; x < width; x++) {
+                    int colorValue = dataBuffer.getElem(pixelPtr++);
+                    for (int i = 0; i < bitOffsets.length; i++) {
+                        int v = (colorValue & bitMasks[i]) >> bitOffsets[i];
+                        currLine[writePtr++] = (byte) (v & 0xFF);
+                    }
+                }
+                linePtr += scanlineStride;
+                consumer.consume(currLine, prevLine);
+                {
+                    byte[] b = currLine;
+                    currLine = prevLine;
+                    prevLine = b;
+                }
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/src/test/java/com/pngencoder/CustomDataBuffers.java
+++ b/src/test/java/com/pngencoder/CustomDataBuffers.java
@@ -1,0 +1,130 @@
+package com.pngencoder;
+
+import java.awt.Point;
+import java.awt.color.ColorSpace;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.ComponentColorModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.DirectColorModel;
+import java.awt.image.PixelInterleavedSampleModel;
+import java.awt.image.SampleModel;
+import java.awt.image.SinglePixelPackedSampleModel;
+import java.awt.image.WritableRaster;
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.nio.ShortBuffer;
+
+class CustomDataBuffers {
+    static class CustomByteBuffer extends DataBuffer {
+        ByteBuffer buffer;
+
+        protected CustomByteBuffer(int size, final int numBanks) {
+            super(DataBuffer.TYPE_BYTE, size, numBanks);
+            buffer = ByteBuffer.allocateDirect(size * numBanks);
+        }
+
+        @Override
+        public int getElem(int bank, int i) {
+            return buffer.get(bank * size + i);
+        }
+
+        @Override
+        public void setElem(int bank, int i, int val) {
+            buffer.put(bank * size + i, (byte) (val & 0xFF));
+        }
+    }
+
+    static class CustomShortBuffer extends DataBuffer {
+        ShortBuffer buffer;
+
+        protected CustomShortBuffer(int size, final int numBanks) {
+            super(DataBuffer.TYPE_USHORT, size, numBanks);
+            buffer = ByteBuffer.allocateDirect(size * numBanks * 2).asShortBuffer();
+        }
+
+        @Override
+        public int getElem(int bank, int i) {
+            return buffer.get(bank * size + i);
+        }
+
+        @Override
+        public void setElem(int bank, int i, int val) {
+            buffer.put(bank * size + i, (short) (val & 0xFFFF));
+        }
+    }
+
+    static class CustomIntBuffer extends DataBuffer {
+        IntBuffer buffer;
+
+        protected CustomIntBuffer(int size, final int numBanks) {
+            super(DataBuffer.TYPE_INT, size, numBanks);
+            buffer = ByteBuffer.allocateDirect(size * numBanks * 4).asIntBuffer();
+        }
+
+        @Override
+        public int getElem(int bank, int i) {
+            return buffer.get(bank * size + i);
+        }
+
+        @Override
+        public void setElem(int bank, int i, int val) {
+            buffer.put(bank * size + i, val);
+        }
+    }
+
+    static final class GenericRasterFactory {
+        public WritableRaster createRaster(final SampleModel model, final DataBuffer buffer, final Point origin) {
+            return new GenericWritableRaster(model, buffer, origin);
+        }
+    }
+
+    private static final GenericRasterFactory RASTER_FACTORY = new GenericRasterFactory();
+
+    static class GenericWritableRaster extends WritableRaster {
+        public GenericWritableRaster(final SampleModel model, final DataBuffer buffer, final Point origin) {
+            super(model, buffer, origin);
+        }
+    }
+
+    static BufferedImage createCompatibleImage(int width, int height, SampleModel sm, ColorModel cm) {
+        DataBuffer buffer;
+        switch (sm.getTransferType()) {
+            case DataBuffer.TYPE_BYTE:
+                buffer = new CustomDataBuffers.CustomByteBuffer(width * height * sm.getNumDataElements(), 1);
+                break;
+            case DataBuffer.TYPE_USHORT:
+                buffer = new CustomDataBuffers.CustomShortBuffer(width * height * sm.getNumDataElements(), 1);
+                break;
+            case DataBuffer.TYPE_INT:
+                buffer = new CustomDataBuffers.CustomIntBuffer(width * height, 1);
+                break;
+            default:
+                throw new RuntimeException("Not implemented!");
+        }
+
+        return new BufferedImage(cm, RASTER_FACTORY.createRaster(sm, buffer, new Point()), cm.isAlphaPremultiplied(),
+                null);
+    }
+
+    static BufferedImage create8BitRGBA(int width, int height, ColorModel colorModel) {
+        PixelInterleavedSampleModel model = new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, width, height, 4, 4 * width, new int[]{0, 1, 2, 3});
+        return createCompatibleImage(width, height, model, colorModel);
+    }
+
+    static BufferedImage create16BitRGBA(int width, int height) {
+        ColorSpace colorSpace = ColorModel.getRGBdefault().getColorSpace();
+        PixelInterleavedSampleModel model = new PixelInterleavedSampleModel(DataBuffer.TYPE_USHORT, width, height, 4, 4 * width, new int[]{0, 1, 2, 3});
+        final ColorModel colorModel = new ComponentColorModel(colorSpace, true, false,
+                ColorModel.TRANSLUCENT, DataBuffer.TYPE_USHORT);
+        return createCompatibleImage(width, height, model, colorModel);
+    }
+
+    static BufferedImage createInt8BitRGBA(int width, int height) {
+        ColorSpace colorSpace = ColorModel.getRGBdefault().getColorSpace();
+        final DirectColorModel colorModel = (DirectColorModel) ColorModel.getRGBdefault();
+
+        SinglePixelPackedSampleModel model = new SinglePixelPackedSampleModel(DataBuffer.TYPE_INT, width, height, colorModel.getMasks());
+        return createCompatibleImage(width, height, model, colorModel);
+    }
+}

--- a/src/test/java/com/pngencoder/PngEncoderScanlineUtilTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderScanlineUtilTest.java
@@ -1,6 +1,5 @@
 package com.pngencoder;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.awt.Graphics2D;
@@ -42,18 +41,6 @@ public class PngEncoderScanlineUtilTest {
     @Test
     public void get4ByteAbgr() throws IOException {
         assertThatScanlineOfTestImageEqualsIntRgbOrArgb(PngEncoderBufferedImageType.TYPE_4BYTE_ABGR, true);
-    }
-
-    @Test
-    @Disabled
-    public void getByteGray() throws IOException {
-        assertThatScanlineOfTestImageEqualsIntRgbOrArgb(PngEncoderBufferedImageType.TYPE_BYTE_GRAY, false);
-    }
-
-    @Test
-    @Disabled
-    public void getUshortGray() throws IOException {
-        assertThatScanlineOfTestImageEqualsIntRgbOrArgb(PngEncoderBufferedImageType.TYPE_USHORT_GRAY, false);
     }
 
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderScanlineUtilTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderScanlineUtilTest.java
@@ -1,15 +1,18 @@
 package com.pngencoder;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
+import java.io.IOException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class PngEncoderScanlineUtilTest {
     @Test
-    public void getIntRgbSize() {
+    public void getIntRgbSize() throws IOException {
         final BufferedImage bufferedImage = PngEncoderTestUtil.createTestImage(PngEncoderBufferedImageType.TYPE_INT_RGB);
         final byte[] data = PngEncoderScanlineUtil.get(bufferedImage);
         final int actual = data.length;
@@ -18,7 +21,7 @@ public class PngEncoderScanlineUtilTest {
     }
 
     @Test
-    public void getIntArgbSize() {
+    public void getIntArgbSize() throws IOException {
         final BufferedImage bufferedImage = PngEncoderTestUtil.createTestImage(PngEncoderBufferedImageType.TYPE_INT_ARGB);
         final byte[] data = PngEncoderScanlineUtil.get(bufferedImage);
         final int actual = data.length;
@@ -27,31 +30,74 @@ public class PngEncoderScanlineUtilTest {
     }
 
     @Test
-    public void getIntBgr() {
+    public void getIntBgr() throws IOException {
         assertThatScanlineOfTestImageEqualsIntRgbOrArgb(PngEncoderBufferedImageType.TYPE_INT_BGR, false);
     }
 
     @Test
-    public void get3ByteBgr() {
+    public void get3ByteBgr() throws IOException {
         assertThatScanlineOfTestImageEqualsIntRgbOrArgb(PngEncoderBufferedImageType.TYPE_3BYTE_BGR, false);
     }
 
     @Test
-    public void get4ByteAbgr() {
+    public void get4ByteAbgr() throws IOException {
         assertThatScanlineOfTestImageEqualsIntRgbOrArgb(PngEncoderBufferedImageType.TYPE_4BYTE_ABGR, true);
     }
 
     @Test
-    public void getByteGray() {
+    @Disabled
+    public void getByteGray() throws IOException {
         assertThatScanlineOfTestImageEqualsIntRgbOrArgb(PngEncoderBufferedImageType.TYPE_BYTE_GRAY, false);
     }
 
     @Test
-    public void getUshortGray() {
+    @Disabled
+    public void getUshortGray() throws IOException {
         assertThatScanlineOfTestImageEqualsIntRgbOrArgb(PngEncoderBufferedImageType.TYPE_USHORT_GRAY, false);
     }
 
-    private void assertThatScanlineOfTestImageEqualsIntRgbOrArgb(PngEncoderBufferedImageType type, boolean alpha) {
+    @Test
+    public void getBinary() throws IOException {
+        assertThatScanlineOfTestImageEqualsIntRgbOrArgb(PngEncoderBufferedImageType.TYPE_BYTE_BINARY, false);
+    }
+
+    @Test
+    public void testCustomByteRGBA() throws IOException {
+        final BufferedImage sourceImage = PngEncoderTestUtil.createTestImage(PngEncoderBufferedImageType.TYPE_4BYTE_ABGR);
+        BufferedImage imgRGBA = CustomDataBuffers.create8BitRGBA(sourceImage.getWidth(), sourceImage.getHeight(), sourceImage.getColorModel());
+        Graphics2D graphics = imgRGBA.createGraphics();
+        graphics.drawImage(sourceImage, 0, 0, null);
+        graphics.dispose();
+        final byte[] actual = PngEncoderScanlineUtil.get(sourceImage);
+        final byte[] expected = PngEncoderScanlineUtil.get(imgRGBA);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void testCustomUShortRGBA() throws IOException {
+        final BufferedImage sourceImage = PngEncoderTestUtil.createTestImage(PngEncoderBufferedImageType.TYPE_4BYTE_ABGR);
+        BufferedImage imgRGBA = CustomDataBuffers.create16BitRGBA(sourceImage.getWidth(), sourceImage.getHeight());
+        Graphics2D graphics = imgRGBA.createGraphics();
+        graphics.drawImage(sourceImage, 0, 0, null);
+        graphics.dispose();
+        final byte[] actual = PngEncoderScanlineUtil.get(sourceImage);
+        final byte[] expected = PngEncoderScanlineUtil.get(imgRGBA);
+        assertThat(actual.length * 2 - sourceImage.getHeight(), is(expected.length));
+    }
+
+    @Test
+    public void testCustomIntRGBA() throws IOException {
+        final BufferedImage sourceImage = PngEncoderTestUtil.createTestImage(PngEncoderBufferedImageType.TYPE_4BYTE_ABGR);
+        BufferedImage imgRGBA = CustomDataBuffers.createInt8BitRGBA(sourceImage.getWidth(), sourceImage.getHeight());
+        Graphics2D graphics = imgRGBA.createGraphics();
+        graphics.drawImage(sourceImage, 0, 0, null);
+        graphics.dispose();
+        final byte[] actual = PngEncoderScanlineUtil.get(sourceImage);
+        final byte[] expected = PngEncoderScanlineUtil.get(imgRGBA);
+        assertThat(actual, is(expected));
+    }
+
+    private void assertThatScanlineOfTestImageEqualsIntRgbOrArgb(PngEncoderBufferedImageType type, boolean alpha) throws IOException {
         final BufferedImage bufferedImage = PngEncoderTestUtil.createTestImage(type);
         final BufferedImage bufferedImageEnsured = PngEncoderBufferedImageConverter.ensureType(bufferedImage, alpha ? PngEncoderBufferedImageType.TYPE_INT_ARGB : PngEncoderBufferedImageType.TYPE_INT_RGB);
         final byte[] actual = PngEncoderScanlineUtil.get(bufferedImage);

--- a/src/test/java/com/pngencoder/PngEncoderTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderTest.java
@@ -24,277 +24,332 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PngEncoderTest {
-	private static final int WHITE = 0xFFFFFFFF;
-	private static final int BLACK = 0xFF000000;
-	private static final int GREEN = 0XFF00FF00;
-	private static final int RED = 0xFFFF0000;
-	private static final int BLUE = 0xFF0000FF;
+    private static final int WHITE = 0xFFFFFFFF;
+    private static final int BLACK = 0xFF000000;
+    private static final int GREEN = 0XFF00FF00;
+    private static final int RED = 0xFFFF0000;
+    private static final int BLUE = 0xFF0000FF;
 
-	private static final BufferedImage ONE_PIXEL = PngEncoderBufferedImageConverter.createFromIntArgb(new int[1], 1, 1);
+    private static final BufferedImage ONE_PIXEL = PngEncoderBufferedImageConverter.createFromIntArgb(
+            new int[1], 1, 1);
 
-	@Test
-	public void testEncode() {
-		byte[] bytes = new PngEncoder().withBufferedImage(ONE_PIXEL).withCompressionLevel(1).toBytes();
+    @Test
+    public void testEncode() {
+        byte[] bytes = new PngEncoder()
+                .withBufferedImage(ONE_PIXEL)
+                .withCompressionLevel(1)
+                .toBytes();
 
-		int pngHeaderLength = PngEncoderLogic.FILE_BEGINNING.length;
-		int ihdrLength = 25; // length(4)+"IHDR"(4)+values(13)+crc(4)
-		int idatLength = 23; // length(4)+"IDAT"(4)+compressed scanline(11)+crc(4)
-		int iendLength = PngEncoderLogic.FILE_ENDING.length;
+        int pngHeaderLength = PngEncoderLogic.FILE_BEGINNING.length;
+        int ihdrLength = 25; // length(4)+"IHDR"(4)+values(13)+crc(4)
+        int idatLength = 23; // length(4)+"IDAT"(4)+compressed scanline(11)+crc(4)
+        int iendLength = PngEncoderLogic.FILE_ENDING.length;
 
-		int expected = pngHeaderLength + ihdrLength + idatLength + iendLength;
-		int actual = bytes.length;
+        int expected = pngHeaderLength + ihdrLength + idatLength + iendLength;
+        int actual = bytes.length;
 
-		assertThat(actual, is(expected));
-	}
+        assertThat(actual, is(expected));
+    }
 
-	@Test
-	public void testEncodeWithSrgb() {
-		byte[] bytes = new PngEncoder().withBufferedImage(ONE_PIXEL).withCompressionLevel(1)
-				.withSrgbRenderingIntent(PngEncoderSrgbRenderingIntent.PERCEPTUAL).toBytes();
+    @Test
+    public void testEncodeWithSrgb() {
+        byte[] bytes = new PngEncoder()
+                .withBufferedImage(ONE_PIXEL)
+                .withCompressionLevel(1)
+                .withSrgbRenderingIntent(PngEncoderSrgbRenderingIntent.PERCEPTUAL)
+                .toBytes();
 
-		int pngHeaderLength = PngEncoderLogic.FILE_BEGINNING.length;
-		int ihdrLength = 25; // length(4)+"IHDR"(4)+values(13)+crc(4)
-		int srgbLength = 13; // length(4)+"sRGB"(4)+value(1)+crc(4)
-		int gamaLength = 16; // length(4)+"gAMA"(4)+value(4)+crc(4)
-		int chrmLength = 44; // length(4)+"sRGB"(4)+value(32)+crc(4)
-		int idatLength = 23; // length(4)+"IDAT"(4)+compressed scanline(11)+crc(4)
-		int iendLength = PngEncoderLogic.FILE_ENDING.length;
+        int pngHeaderLength = PngEncoderLogic.FILE_BEGINNING.length;
+        int ihdrLength = 25; // length(4)+"IHDR"(4)+values(13)+crc(4)
+        int srgbLength = 13; // length(4)+"sRGB"(4)+value(1)+crc(4)
+        int gamaLength = 16; // length(4)+"gAMA"(4)+value(4)+crc(4)
+        int chrmLength = 44; // length(4)+"sRGB"(4)+value(32)+crc(4)
+        int idatLength = 23; // length(4)+"IDAT"(4)+compressed scanline(11)+crc(4)
+        int iendLength = PngEncoderLogic.FILE_ENDING.length;
 
-		int expected = pngHeaderLength + ihdrLength + srgbLength + gamaLength + chrmLength + idatLength + iendLength;
-		int actual = bytes.length;
+        int expected = pngHeaderLength + ihdrLength + srgbLength + gamaLength + chrmLength + idatLength + iendLength;
+        int actual = bytes.length;
 
-		assertThat(actual, is(expected));
-	}
+        assertThat(actual, is(expected));
+    }
 
-	@Test
-	public void testEncodeWithPhysicalPixelDimensions() {
-		byte[] bytes = new PngEncoder().withBufferedImage(ONE_PIXEL).withCompressionLevel(1)
-				.withPhysicalPixelDimensions(PngEncoderPhysicalPixelDimensions.dotsPerInch(300)).toBytes();
+    @Test
+    public void testEncodeWithPhysicalPixelDimensions() {
+        byte[] bytes = new PngEncoder()
+                .withBufferedImage(ONE_PIXEL)
+                .withCompressionLevel(1)
+                .withPhysicalPixelDimensions(PngEncoderPhysicalPixelDimensions.dotsPerInch(300))
+                .toBytes();
 
-		int pngHeaderLength = PngEncoderLogic.FILE_BEGINNING.length;
-		int ihdrLength = 25; // length(4)+"IHDR"(4)+values(13)+crc(4)
-		int physLength = 21; // length(4)+"pHYs"(4)+values(9)+crc(4)
-		int idatLength = 23; // length(4)+"IDAT"(4)+compressed scanline(11)+crc(4)
-		int iendLength = PngEncoderLogic.FILE_ENDING.length;
+        int pngHeaderLength = PngEncoderLogic.FILE_BEGINNING.length;
+        int ihdrLength = 25; // length(4)+"IHDR"(4)+values(13)+crc(4)
+        int physLength = 21; // length(4)+"pHYs"(4)+values(9)+crc(4)
+        int idatLength = 23; // length(4)+"IDAT"(4)+compressed scanline(11)+crc(4)
+        int iendLength = PngEncoderLogic.FILE_ENDING.length;
 
-		int expected = pngHeaderLength + ihdrLength + physLength + idatLength + iendLength;
-		int actual = bytes.length;
+        int expected = pngHeaderLength + ihdrLength + physLength + idatLength + iendLength;
+        int actual = bytes.length;
 
-		assertThat(actual, is(expected));
-	}
+        assertThat(actual, is(expected));
+    }
 
-	@Test
-	public void testEncodeAndReadOpaque() throws IOException {
-		int width = 3;
-		int height = 2;
-		int[] image = { WHITE, BLACK, RED, GREEN, WHITE, BLUE };
-		BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(image, width, height);
-		byte[] bytes = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1).toBytes();
+    @Test
+    public void testEncodeAndReadOpaque() throws IOException {
+        int width = 3;
+        int height = 2;
+        int[] image = {
+                WHITE, BLACK, RED,
+                GREEN, WHITE, BLUE
+        };
+        BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(
+                image, width, height);
+        byte[] bytes = new PngEncoder()
+                .withBufferedImage(bufferedImage)
+                .withCompressionLevel(1)
+                .toBytes();
 
-		int[] actual = readWithImageIOgetRGB(bytes);
-		int[] expected = image;
-		assertThat(actual, is(expected));
-	}
+        int[] actual = readWithImageIOgetRGB(bytes);
+        int[] expected = image;
+        assertThat(actual, is(expected));
+    }
 
-	@Test
-	public void testEncodeAndReadBlackTransparency() throws IOException {
-		int width = 0xFF;
-		int height = 1;
-		int[] image = new int[width];
-		for (int x = 0; x < width; x++) {
-			image[x] = x << 24;
-		}
-		BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(image, width, height);
-		byte[] bytes = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1).toBytes();
+    @Test
+    public void testEncodeAndReadBlackTransparency() throws IOException {
+        int width = 0xFF;
+        int height = 1;
+        int[] image = new int[width];
+        for (int x = 0; x < width; x++) {
+            image[x] = x << 24;
+        }
+        BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(
+                image, width, height);
+        byte[] bytes = new PngEncoder()
+                .withBufferedImage(bufferedImage)
+                .withCompressionLevel(1)
+                .toBytes();
 
-		int[] actual = readWithImageIOgetRGB(bytes);
-		int[] expected = image;
-		assertThat(actual, is(expected));
-	}
+        int[] actual = readWithImageIOgetRGB(bytes);
+        int[] expected = image;
+        assertThat(actual, is(expected));
+    }
 
-	@Test
-	public void testEncodeAndReadRedTransparency() throws IOException {
-		int width = 0xFF;
-		int height = 1;
-		int[] image = new int[width];
-		for (int x = 0; x < width; x++) {
-			int pixel = (x << 24) + (x << 16);
-			image[x] = pixel;
-		}
-		BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(image, width, height);
-		byte[] bytes = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1).toBytes();
+    @Test
+    public void testEncodeAndReadRedTransparency() throws IOException {
+        int width = 0xFF;
+        int height = 1;
+        int[] image = new int[width];
+        for (int x = 0; x < width; x++) {
+            int pixel = (x << 24) + (x << 16);
+            image[x] = pixel;
+        }
+        BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(
+                image, width, height);
+        byte[] bytes = new PngEncoder()
+                .withBufferedImage(bufferedImage)
+                .withCompressionLevel(1)
+                .toBytes();
 
-		int[] actual = readWithImageIOgetRGB(bytes);
-		int[] expected = image;
-		assertThat(actual, is(expected));
-	}
+        int[] actual = readWithImageIOgetRGB(bytes);
+        int[] expected = image;
+        assertThat(actual, is(expected));
+    }
 
-	@Test
-	public void testEncodeAndReadRedTransparencyPredictor() throws IOException {
-		int width = 0xFF;
-		int height = 1;
-		int[] image = new int[width];
-		for (int x = 0; x < width; x++) {
-			int pixel = (x << 24) + (x << 16);
-			image[x] = pixel;
-		}
-		BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(image, width, height);
-		byte[] bytes = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1)
-				.withPredictorEncoding(true).toBytes();
+    @Test
+    public void testEncodeAndReadRedTransparencyPredictor() throws IOException {
+        int width = 0xFF;
+        int height = 1;
+        int[] image = new int[width];
+        for (int x = 0; x < width; x++) {
+            int pixel = (x << 24) + (x << 16);
+            image[x] = pixel;
+        }
+        BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(image, width, height);
+        byte[] bytes = new PngEncoder()
+                .withBufferedImage(bufferedImage)
+                .withCompressionLevel(1)
+                .withPredictorEncoding(true)
+                .toBytes();
 
-		int[] actual = readWithImageIOgetRGB(bytes);
-		int[] expected = image;
-		assertThat(actual, is(expected));
-	}
+        int[] actual = readWithImageIOgetRGB(bytes);
+        int[] expected = image;
+        assertThat(actual, is(expected));
+    }
 
-	@Test
-	public void testPredictorEncoding() throws IOException {
-		final BufferedImage bufferedImage = PngEncoderTestUtil
-				.createTestImage(PngEncoderBufferedImageType.TYPE_INT_ARGB);
+    @Test
+    public void testPredictorEncoding() throws IOException {
+        final BufferedImage bufferedImage = PngEncoderTestUtil
+                .createTestImage(PngEncoderBufferedImageType.TYPE_INT_ARGB);
 
-		byte[] bytes = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1)
-				.withMultiThreadedCompressionEnabled(false)
-				.withPredictorEncoding(true).toBytes();
+        byte[] bytes = new PngEncoder()
+                .withBufferedImage(bufferedImage)
+                .withCompressionLevel(1)
+                .withMultiThreadedCompressionEnabled(false)
+                .withPredictorEncoding(true)
+                .toBytes();
 
-		BufferedImage backReadImage = readWithImageIO(bytes);
-		int[] actual = toIntArgb(backReadImage);
-		int[] expected = toIntArgb(bufferedImage);
-		assertThat(actual, is(expected));
-	}
+        BufferedImage backReadImage = readWithImageIO(bytes);
+        int[] actual = toIntArgb(backReadImage);
+        int[] expected = toIntArgb(bufferedImage);
+        assertThat(actual, is(expected));
+    }
 
-	@Test
-	public void testPredictorEncodingWithImage() throws IOException {
-		final BufferedImage bufferedImage = ImageIO
-				.read(Objects.requireNonNull(PngEncoderTest.class.getResourceAsStream("/png-encoder-logo.png")));
+    @Test
+    public void testPredictorEncodingWithImage() throws IOException {
+        final BufferedImage bufferedImage = ImageIO
+                .read(Objects.requireNonNull(PngEncoderTest.class.getResourceAsStream("/png-encoder-logo.png")));
 
-		byte[] bytes = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1)
-				.withPredictorEncoding(true).toBytes();
+        byte[] bytes = new PngEncoder()
+                .withBufferedImage(bufferedImage)
+                .withCompressionLevel(1)
+                .withPredictorEncoding(true)
+                .toBytes();
 
-		BufferedImage backReadImage = readWithImageIO(bytes);
-		int[] actual = toIntArgb(backReadImage);
-		int[] expected = toIntArgb(bufferedImage);
-		assertThat(actual, is(expected));
-	}
+        BufferedImage backReadImage = readWithImageIO(bytes);
+        int[] actual = toIntArgb(backReadImage);
+        int[] expected = toIntArgb(bufferedImage);
+        assertThat(actual, is(expected));
+    }
 
-	@Test
-	public void testpredictorEncodingCompareSize() throws IOException {
-		final BufferedImage bufferedImage = ImageIO
-				.read(Objects.requireNonNull(PngEncoderTest.class.getResourceAsStream("/png-encoder-logo.png")));
+    @Test
+    public void testpredictorEncodingCompareSize() throws IOException {
+        final BufferedImage bufferedImage = ImageIO
+                .read(Objects.requireNonNull(PngEncoderTest.class.getResourceAsStream("/png-encoder-logo.png")));
 
-		byte[] bytesPred1 = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1)
-				.withPredictorEncoding(true).toBytes();
-		byte[] bytesPred9 = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(9)
-				.withPredictorEncoding(true).toBytes();
-		byte[] bytesBaseline1 = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1).toBytes();
-		byte[] bytesBaseline9 = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(9).toBytes();
+        byte[] bytesPred1 = new PngEncoder()
+                .withBufferedImage(bufferedImage)
+                .withCompressionLevel(1)
+                .withPredictorEncoding(true)
+                .toBytes();
+        byte[] bytesPred9 = new PngEncoder()
+                .withBufferedImage(bufferedImage)
+                .withCompressionLevel(9)
+                .withPredictorEncoding(true)
+                .toBytes();
+        byte[] bytesBaseline1 = new PngEncoder()
+                .withBufferedImage(bufferedImage)
+                .withCompressionLevel(1)
+                .toBytes();
+        byte[] bytesBaseline9 = new PngEncoder()
+                .withBufferedImage(bufferedImage)
+                .withCompressionLevel(9)
+                .toBytes();
 
-		System.out.println("Baseline 1: " + bytesBaseline1.length);
-		System.out.println("Baseline 9: " + bytesBaseline9.length);
-		System.out.println("Preditor 1: " + bytesPred1.length);
-		System.out.println("Preditor 9: " + bytesPred9.length);
-		assertThat("Predictor must be smaller", bytesPred1.length < bytesBaseline1.length);
-		assertThat("Predictor must be smaller", bytesPred9.length < bytesBaseline9.length);
-	}
+        System.out.println("Baseline 1: " + bytesBaseline1.length);
+        System.out.println("Baseline 9: " + bytesBaseline9.length);
+        System.out.println("Preditor 1: " + bytesPred1.length);
+        System.out.println("Preditor 9: " + bytesPred9.length);
+        assertThat("Predictor must be smaller", bytesPred1.length < bytesBaseline1.length);
+        assertThat("Predictor must be smaller", bytesPred9.length < bytesBaseline9.length);
+    }
 
-	@Test
-	public void testEncodeWithSrgbAndReadMetadata() throws IOException {
-		int width = 3;
-		int height = 2;
-		int[] image = { WHITE, BLACK, RED, GREEN, WHITE, BLUE };
-		BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(image, width, height);
-		byte[] bytes = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1)
-				.withSrgbRenderingIntent(PngEncoderSrgbRenderingIntent.PERCEPTUAL).toBytes();
+    @Test
+    public void testEncodeWithSrgbAndReadMetadata() throws IOException {
+        int width = 3;
+        int height = 2;
+        int[] image = {
+                WHITE, BLACK, RED,
+                GREEN, WHITE, BLUE
+        };
+        BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(
+                image, width, height);
+        byte[] bytes = new PngEncoder()
+                .withBufferedImage(bufferedImage)
+                .withCompressionLevel(1)
+                .withSrgbRenderingIntent(PngEncoderSrgbRenderingIntent.PERCEPTUAL)
+                .toBytes();
 
-		IIOMetadata metadata = getImageMetaDataWithImageIO(bytes);
-		IIOMetadataNode root = (IIOMetadataNode) metadata.getAsTree(metadata.getNativeMetadataFormatName());
+        IIOMetadata metadata = getImageMetaDataWithImageIO(bytes);
+        IIOMetadataNode root = (IIOMetadataNode) metadata.getAsTree(metadata.getNativeMetadataFormatName());
 
-		assertThat(root.getElementsByTagName("sRGB").getLength(), is(1));
-		assertThat(root.getElementsByTagName("cHRM").getLength(), is(1));
-		assertThat(root.getElementsByTagName("gAMA").getLength(), is(1));
-	}
+        assertThat(root.getElementsByTagName("sRGB").getLength(), is(1));
+        assertThat(root.getElementsByTagName("cHRM").getLength(), is(1));
+        assertThat(root.getElementsByTagName("gAMA").getLength(), is(1));
+    }
 
-	@Test
-	public void testEncodeWithPhysicalPixelDimensionsAndReadMetadata() throws IOException {
-		int dotsPerInch = 150;
-		byte[] bytes = new PngEncoder().withBufferedImage(ONE_PIXEL).withCompressionLevel(1)
-				.withPhysicalPixelDimensions(PngEncoderPhysicalPixelDimensions.dotsPerInch(dotsPerInch)).toBytes();
+    @Test
+    public void testEncodeWithPhysicalPixelDimensionsAndReadMetadata() throws IOException {
+        int dotsPerInch = 150;
+        byte[] bytes = new PngEncoder()
+                .withBufferedImage(ONE_PIXEL)
+                .withCompressionLevel(1)
+                .withPhysicalPixelDimensions(PngEncoderPhysicalPixelDimensions.dotsPerInch(dotsPerInch))
+                .toBytes();
 
-		IIOMetadata metadata = getImageMetaDataWithImageIO(bytes);
-		IIOMetadataNode root = (IIOMetadataNode) metadata.getAsTree("javax_imageio_1.0");
-		float horizontalPixelSize = Float
-				.parseFloat(((Element) root.getElementsByTagName("HorizontalPixelSize").item(0)).getAttribute("value"));
-		float verticalPixelSize = Float
-				.parseFloat(((Element) root.getElementsByTagName("VerticalPixelSize").item(0)).getAttribute("value"));
+        IIOMetadata metadata = getImageMetaDataWithImageIO(bytes);
+        IIOMetadataNode root = (IIOMetadataNode) metadata.getAsTree("javax_imageio_1.0");
+        float horizontalPixelSize = Float.parseFloat(((Element) root.getElementsByTagName("HorizontalPixelSize").item(0)).getAttribute("value"));
+        float verticalPixelSize = Float.parseFloat(((Element) root.getElementsByTagName("VerticalPixelSize").item(0)).getAttribute("value"));
 
-		// Standard metadata contains the width/height of a pixel in millimeters
-		float mmPerInch = 25.4f;
-		assertThat(Math.round(mmPerInch / horizontalPixelSize), is(dotsPerInch));
-		assertThat(Math.round(mmPerInch / verticalPixelSize), is(dotsPerInch));
-	}
+        // Standard metadata contains the width/height of a pixel in millimeters
+        float mmPerInch = 25.4f;
+        assertThat(Math.round(mmPerInch/horizontalPixelSize), is(dotsPerInch));
+        assertThat(Math.round(mmPerInch/verticalPixelSize), is(dotsPerInch));
+    }
 
-	private static int[] readWithImageIOgetRGB(byte[] fileBytes) throws IOException {
-		BufferedImage bufferedImage = readWithImageIO(fileBytes);
+    private static int[] readWithImageIOgetRGB(byte[] fileBytes) throws IOException {
+        BufferedImage bufferedImage = readWithImageIO(fileBytes);
 
-		return toIntArgb(bufferedImage);
-	}
+        return toIntArgb(bufferedImage);
+    }
 
-	private static int[] toIntArgb(BufferedImage bufferedImage) {
-		int width = bufferedImage.getWidth();
-		int height = bufferedImage.getHeight();
-		int[] argbImage = new int[width * height];
+    private static int[] toIntArgb(BufferedImage bufferedImage) {
+        int width = bufferedImage.getWidth();
+        int height = bufferedImage.getHeight();
+        int[] argbImage = new int[width * height];
 
-		for (int y = 0; y < height; y++) {
-			for (int x = 0; x < width; x++) {
-				argbImage[y * width + x] = bufferedImage.getRGB(x, y);
-			}
-		}
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                argbImage[y * width + x] = bufferedImage.getRGB(x, y);
+            }
+        }
 
-		return argbImage;
-	}
+        return argbImage;
+    }
 
-	public static BufferedImage readWithImageIO(byte[] filesBytes) throws IOException {
-		try (ByteArrayInputStream bais = new ByteArrayInputStream(filesBytes)) {
-			return ImageIO.read(bais);
-		}
-	}
+    public static BufferedImage readWithImageIO(byte[] filesBytes) throws IOException {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(filesBytes)) {
+            return ImageIO.read(bais);
+        }
+    }
 
-	public static IIOMetadata getImageMetaDataWithImageIO(byte[] filesBytes) throws IOException {
-		try (ByteArrayInputStream inputStream = new ByteArrayInputStream(filesBytes);
-				ImageInputStream input = ImageIO.createImageInputStream(inputStream)) {
-			Iterator<ImageReader> readers = ImageIO.getImageReaders(input);
-			ImageReader reader = readers.next();
+    public static IIOMetadata getImageMetaDataWithImageIO(byte[] filesBytes) throws IOException {
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(filesBytes);
+                ImageInputStream input = ImageIO.createImageInputStream(inputStream)) {
+            Iterator<ImageReader> readers = ImageIO.getImageReaders(input);
+            ImageReader reader = readers.next();
 
-			reader.setInput(input);
-			return reader.getImageMetadata(0);
-		}
-	}
+            reader.setInput(input);
+            return reader.getImageMetadata(0);
+        }
+    }
 
-	@ParameterizedTest()
-	@MethodSource("validCompressionLevels")
-	public void validCompressionLevel(int compressionLevel) {
-		assertDoesNotThrow(() -> new PngEncoder().withCompressionLevel(compressionLevel));
-	}
+    @ParameterizedTest()
+    @MethodSource("validCompressionLevels")
+    public void validCompressionLevel(int compressionLevel) {
+        assertDoesNotThrow(() -> new PngEncoder().withCompressionLevel(compressionLevel));
+    }
 
-	static IntStream validCompressionLevels() {
-		// Compression level value must be between -1 and 9 inclusive.
-		return IntStream.rangeClosed(-1, 9);
-	}
+    static IntStream validCompressionLevels() {
+        // Compression level value must be between -1 and 9 inclusive.
+        return IntStream.rangeClosed(-1, 9);
+    }
 
-	@ParameterizedTest()
-	@ValueSource(ints = { -2, 10 })
-	public void invalidCompressionLevel(int compressionLevel) {
-		assertThrows(IllegalArgumentException.class, () -> new PngEncoder().withCompressionLevel(compressionLevel));
-	}
+    @ParameterizedTest()
+    @ValueSource(ints = {-2, 10})
+    public void invalidCompressionLevel(int compressionLevel) {
+        assertThrows(IllegalArgumentException.class, () -> new PngEncoder().withCompressionLevel(compressionLevel));
+    }
 
-	@Test
-	public void testEncodeWithoutImage() {
+    @Test
+    public void testEncodeWithoutImage() {
         // Document the fact that, at the moment, attempting to encode without providing an
-		// image throws NullPointException.
-		PngEncoder emptyEncoder = new PngEncoder();
-		assertThrows(NullPointerException.class, () -> emptyEncoder.toBytes());
+        // image throws NullPointException.
+        PngEncoder emptyEncoder = new PngEncoder();
+        assertThrows(NullPointerException.class, () -> emptyEncoder.toBytes());
 
-		PngEncoder encoderWithoutImage = new PngEncoder().withCompressionLevel(9)
-				.withMultiThreadedCompressionEnabled(true);
-		assertThrows(NullPointerException.class, () -> encoderWithoutImage.toBytes());
-	}
+        PngEncoder encoderWithoutImage = new PngEncoder()
+                .withCompressionLevel(9)
+                .withMultiThreadedCompressionEnabled(true);
+        assertThrows(NullPointerException.class, () -> encoderWithoutImage.toBytes());
+    }
 }

--- a/src/test/java/com/pngencoder/PngEncoderTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderTest.java
@@ -10,6 +10,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.stream.IntStream;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
@@ -23,240 +24,277 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PngEncoderTest {
-    private static final int WHITE = 0xFFFFFFFF;
-    private static final int BLACK = 0xFF000000;
-    private static final int GREEN = 0XFF00FF00;
-    private static final int RED = 0xFFFF0000;
-    private static final int BLUE = 0xFF0000FF;
+	private static final int WHITE = 0xFFFFFFFF;
+	private static final int BLACK = 0xFF000000;
+	private static final int GREEN = 0XFF00FF00;
+	private static final int RED = 0xFFFF0000;
+	private static final int BLUE = 0xFF0000FF;
 
-    private static final BufferedImage ONE_PIXEL = PngEncoderBufferedImageConverter.createFromIntArgb(
-            new int[1], 1, 1);
+	private static final BufferedImage ONE_PIXEL = PngEncoderBufferedImageConverter.createFromIntArgb(new int[1], 1, 1);
 
-    @Test
-    public void testEncode() {
-        byte[] bytes = new PngEncoder()
-                .withBufferedImage(ONE_PIXEL)
-                .withCompressionLevel(1)
-                .toBytes();
+	@Test
+	public void testEncode() {
+		byte[] bytes = new PngEncoder().withBufferedImage(ONE_PIXEL).withCompressionLevel(1).toBytes();
 
-        int pngHeaderLength = PngEncoderLogic.FILE_BEGINNING.length;
-        int ihdrLength = 25; // length(4)+"IHDR"(4)+values(13)+crc(4)
-        int idatLength = 23; // length(4)+"IDAT"(4)+compressed scanline(11)+crc(4)
-        int iendLength = PngEncoderLogic.FILE_ENDING.length;
+		int pngHeaderLength = PngEncoderLogic.FILE_BEGINNING.length;
+		int ihdrLength = 25; // length(4)+"IHDR"(4)+values(13)+crc(4)
+		int idatLength = 23; // length(4)+"IDAT"(4)+compressed scanline(11)+crc(4)
+		int iendLength = PngEncoderLogic.FILE_ENDING.length;
 
-        int expected = pngHeaderLength + ihdrLength + idatLength + iendLength;
-        int actual = bytes.length;
+		int expected = pngHeaderLength + ihdrLength + idatLength + iendLength;
+		int actual = bytes.length;
 
-        assertThat(actual, is(expected));
-    }
+		assertThat(actual, is(expected));
+	}
 
-    @Test
-    public void testEncodeWithSrgb() {
-        byte[] bytes = new PngEncoder()
-                .withBufferedImage(ONE_PIXEL)
-                .withCompressionLevel(1)
-                .withSrgbRenderingIntent(PngEncoderSrgbRenderingIntent.PERCEPTUAL)
-                .toBytes();
+	@Test
+	public void testEncodeWithSrgb() {
+		byte[] bytes = new PngEncoder().withBufferedImage(ONE_PIXEL).withCompressionLevel(1)
+				.withSrgbRenderingIntent(PngEncoderSrgbRenderingIntent.PERCEPTUAL).toBytes();
 
-        int pngHeaderLength = PngEncoderLogic.FILE_BEGINNING.length;
-        int ihdrLength = 25; // length(4)+"IHDR"(4)+values(13)+crc(4)
-        int srgbLength = 13; // length(4)+"sRGB"(4)+value(1)+crc(4)
-        int gamaLength = 16; // length(4)+"gAMA"(4)+value(4)+crc(4)
-        int chrmLength = 44; // length(4)+"sRGB"(4)+value(32)+crc(4)
-        int idatLength = 23; // length(4)+"IDAT"(4)+compressed scanline(11)+crc(4)
-        int iendLength = PngEncoderLogic.FILE_ENDING.length;
+		int pngHeaderLength = PngEncoderLogic.FILE_BEGINNING.length;
+		int ihdrLength = 25; // length(4)+"IHDR"(4)+values(13)+crc(4)
+		int srgbLength = 13; // length(4)+"sRGB"(4)+value(1)+crc(4)
+		int gamaLength = 16; // length(4)+"gAMA"(4)+value(4)+crc(4)
+		int chrmLength = 44; // length(4)+"sRGB"(4)+value(32)+crc(4)
+		int idatLength = 23; // length(4)+"IDAT"(4)+compressed scanline(11)+crc(4)
+		int iendLength = PngEncoderLogic.FILE_ENDING.length;
 
-        int expected = pngHeaderLength + ihdrLength + srgbLength + gamaLength + chrmLength + idatLength + iendLength;
-        int actual = bytes.length;
+		int expected = pngHeaderLength + ihdrLength + srgbLength + gamaLength + chrmLength + idatLength + iendLength;
+		int actual = bytes.length;
 
-        assertThat(actual, is(expected));
-    }
+		assertThat(actual, is(expected));
+	}
 
-    @Test
-    public void testEncodeWithPhysicalPixelDimensions() {
-        byte[] bytes = new PngEncoder()
-                .withBufferedImage(ONE_PIXEL)
-                .withCompressionLevel(1)
-                .withPhysicalPixelDimensions(PngEncoderPhysicalPixelDimensions.dotsPerInch(300))
-                .toBytes();
+	@Test
+	public void testEncodeWithPhysicalPixelDimensions() {
+		byte[] bytes = new PngEncoder().withBufferedImage(ONE_PIXEL).withCompressionLevel(1)
+				.withPhysicalPixelDimensions(PngEncoderPhysicalPixelDimensions.dotsPerInch(300)).toBytes();
 
-        int pngHeaderLength = PngEncoderLogic.FILE_BEGINNING.length;
-        int ihdrLength = 25; // length(4)+"IHDR"(4)+values(13)+crc(4)
-        int physLength = 21; // length(4)+"pHYs"(4)+values(9)+crc(4)
-        int idatLength = 23; // length(4)+"IDAT"(4)+compressed scanline(11)+crc(4)
-        int iendLength = PngEncoderLogic.FILE_ENDING.length;
+		int pngHeaderLength = PngEncoderLogic.FILE_BEGINNING.length;
+		int ihdrLength = 25; // length(4)+"IHDR"(4)+values(13)+crc(4)
+		int physLength = 21; // length(4)+"pHYs"(4)+values(9)+crc(4)
+		int idatLength = 23; // length(4)+"IDAT"(4)+compressed scanline(11)+crc(4)
+		int iendLength = PngEncoderLogic.FILE_ENDING.length;
 
-        int expected = pngHeaderLength + ihdrLength + physLength + idatLength + iendLength;
-        int actual = bytes.length;
+		int expected = pngHeaderLength + ihdrLength + physLength + idatLength + iendLength;
+		int actual = bytes.length;
 
-        assertThat(actual, is(expected));
-    }
+		assertThat(actual, is(expected));
+	}
 
-    @Test
-    public void testEncodeAndReadOpaque() throws IOException {
-        int width = 3;
-        int height = 2;
-        int[] image = {
-                WHITE, BLACK, RED,
-                GREEN, WHITE, BLUE
-        };
-        BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(
-                image, width, height);
-        byte[] bytes = new PngEncoder()
-                .withBufferedImage(bufferedImage)
-                .withCompressionLevel(1)
-                .toBytes();
+	@Test
+	public void testEncodeAndReadOpaque() throws IOException {
+		int width = 3;
+		int height = 2;
+		int[] image = { WHITE, BLACK, RED, GREEN, WHITE, BLUE };
+		BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(image, width, height);
+		byte[] bytes = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1).toBytes();
 
-        int[] actual = readWithImageIOgetRGB(bytes);
-        int[] expected = image;
-        assertThat(actual, is(expected));
-    }
+		int[] actual = readWithImageIOgetRGB(bytes);
+		int[] expected = image;
+		assertThat(actual, is(expected));
+	}
 
-    @Test
-    public void testEncodeAndReadBlackTransparency() throws IOException {
-        int width = 0xFF;
-        int height = 1;
-        int[] image = new int[width];
-        for (int x = 0; x < width; x++) {
-            image[x] = x << 24;
-        }
-        BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(
-                image, width, height);
-        byte[] bytes = new PngEncoder()
-                .withBufferedImage(bufferedImage)
-                .withCompressionLevel(1)
-                .toBytes();
+	@Test
+	public void testEncodeAndReadBlackTransparency() throws IOException {
+		int width = 0xFF;
+		int height = 1;
+		int[] image = new int[width];
+		for (int x = 0; x < width; x++) {
+			image[x] = x << 24;
+		}
+		BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(image, width, height);
+		byte[] bytes = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1).toBytes();
 
-        int[] actual = readWithImageIOgetRGB(bytes);
-        int[] expected = image;
-        assertThat(actual, is(expected));
-    }
+		int[] actual = readWithImageIOgetRGB(bytes);
+		int[] expected = image;
+		assertThat(actual, is(expected));
+	}
 
-    @Test
-    public void testEncodeAndReadRedTransparency() throws IOException {
-        int width = 0xFF;
-        int height = 1;
-        int[] image = new int[width];
-        for (int x = 0; x < width; x++) {
-            int pixel = (x << 24) + (x << 16);
-            image[x] = pixel;
-        }
-        BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(
-                image, width, height);
-        byte[] bytes = new PngEncoder()
-                .withBufferedImage(bufferedImage)
-                .withCompressionLevel(1)
-                .toBytes();
+	@Test
+	public void testEncodeAndReadRedTransparency() throws IOException {
+		int width = 0xFF;
+		int height = 1;
+		int[] image = new int[width];
+		for (int x = 0; x < width; x++) {
+			int pixel = (x << 24) + (x << 16);
+			image[x] = pixel;
+		}
+		BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(image, width, height);
+		byte[] bytes = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1).toBytes();
 
-        int[] actual = readWithImageIOgetRGB(bytes);
-        int[] expected = image;
-        assertThat(actual, is(expected));
-    }
+		int[] actual = readWithImageIOgetRGB(bytes);
+		int[] expected = image;
+		assertThat(actual, is(expected));
+	}
 
+	@Test
+	public void testEncodeAndReadRedTransparencyPredictor() throws IOException {
+		int width = 0xFF;
+		int height = 1;
+		int[] image = new int[width];
+		for (int x = 0; x < width; x++) {
+			int pixel = (x << 24) + (x << 16);
+			image[x] = pixel;
+		}
+		BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(image, width, height);
+		byte[] bytes = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1)
+				.withPredictorEncoding(true).toBytes();
 
-    @Test
-    public void testEncodeWithSrgbAndReadMetadata() throws IOException {
-        int width = 3;
-        int height = 2;
-        int[] image = {
-                WHITE, BLACK, RED,
-                GREEN, WHITE, BLUE
-        };
-        BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(
-                image, width, height);
-        byte[] bytes = new PngEncoder()
-                .withBufferedImage(bufferedImage)
-                .withCompressionLevel(1)
-                .withSrgbRenderingIntent(PngEncoderSrgbRenderingIntent.PERCEPTUAL)
-                .toBytes();
+		int[] actual = readWithImageIOgetRGB(bytes);
+		int[] expected = image;
+		assertThat(actual, is(expected));
+	}
 
-        IIOMetadata metadata = getImageMetaDataWithImageIO(bytes);
-        IIOMetadataNode root = (IIOMetadataNode) metadata.getAsTree(metadata.getNativeMetadataFormatName());
+	@Test
+	public void testPredictorEncoding() throws IOException {
+		final BufferedImage bufferedImage = PngEncoderTestUtil
+				.createTestImage(PngEncoderBufferedImageType.TYPE_INT_ARGB);
 
-        assertThat(root.getElementsByTagName("sRGB").getLength(), is(1));
-        assertThat(root.getElementsByTagName("cHRM").getLength(), is(1));
-        assertThat(root.getElementsByTagName("gAMA").getLength(), is(1));
-    }
+		byte[] bytes = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1)
+				.withMultiThreadedCompressionEnabled(false)
+				.withPredictorEncoding(true).toBytes();
 
-    @Test
-    public void testEncodeWithPhysicalPixelDimensionsAndReadMetadata() throws IOException {
-        int dotsPerInch = 150;
-        byte[] bytes = new PngEncoder()
-                .withBufferedImage(ONE_PIXEL)
-                .withCompressionLevel(1)
-                .withPhysicalPixelDimensions(PngEncoderPhysicalPixelDimensions.dotsPerInch(dotsPerInch))
-                .toBytes();
+		BufferedImage backReadImage = readWithImageIO(bytes);
+		int[] actual = toIntArgb(backReadImage);
+		int[] expected = toIntArgb(bufferedImage);
+		assertThat(actual, is(expected));
+	}
 
-        IIOMetadata metadata = getImageMetaDataWithImageIO(bytes);
-        IIOMetadataNode root = (IIOMetadataNode) metadata.getAsTree("javax_imageio_1.0");
-        float horizontalPixelSize = Float.parseFloat(((Element) root.getElementsByTagName("HorizontalPixelSize").item(0)).getAttribute("value"));
-        float verticalPixelSize = Float.parseFloat(((Element) root.getElementsByTagName("VerticalPixelSize").item(0)).getAttribute("value"));
+	@Test
+	public void testPredictorEncodingWithImage() throws IOException {
+		final BufferedImage bufferedImage = ImageIO
+				.read(Objects.requireNonNull(PngEncoderTest.class.getResourceAsStream("/png-encoder-logo.png")));
 
-        // Standard metadata contains the width/height of a pixel in millimeters
-        float mmPerInch = 25.4f;
-        assertThat(Math.round(mmPerInch/horizontalPixelSize), is(dotsPerInch));
-        assertThat(Math.round(mmPerInch/verticalPixelSize), is(dotsPerInch));
-    }
+		byte[] bytes = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1)
+				.withPredictorEncoding(true).toBytes();
 
-    private static int[] readWithImageIOgetRGB(byte[] fileBytes) throws IOException {
-        BufferedImage bufferedImage = readWithImageIO(fileBytes);
+		BufferedImage backReadImage = readWithImageIO(bytes);
+		int[] actual = toIntArgb(backReadImage);
+		int[] expected = toIntArgb(bufferedImage);
+		assertThat(actual, is(expected));
+	}
 
-        int width = bufferedImage.getWidth();
-        int height = bufferedImage.getHeight();
-        int[] argbImage = new int[width * height];
+	@Test
+	public void testpredictorEncodingCompareSize() throws IOException {
+		final BufferedImage bufferedImage = ImageIO
+				.read(Objects.requireNonNull(PngEncoderTest.class.getResourceAsStream("/png-encoder-logo.png")));
 
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                argbImage[y*width + x] = bufferedImage.getRGB(x, y);
-            }
-        }
+		byte[] bytesPred1 = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1)
+				.withPredictorEncoding(true).toBytes();
+		byte[] bytesPred9 = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(9)
+				.withPredictorEncoding(true).toBytes();
+		byte[] bytesBaseline1 = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1).toBytes();
+		byte[] bytesBaseline9 = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(9).toBytes();
 
-        return argbImage;
-    }
+		System.out.println("Baseline 1: " + bytesBaseline1.length);
+		System.out.println("Baseline 9: " + bytesBaseline9.length);
+		System.out.println("Preditor 1: " + bytesPred1.length);
+		System.out.println("Preditor 9: " + bytesPred9.length);
+		assertThat("Predictor must be smaller", bytesPred1.length < bytesBaseline1.length);
+		assertThat("Predictor must be smaller", bytesPred9.length < bytesBaseline9.length);
+	}
 
-    public static BufferedImage readWithImageIO(byte[] filesBytes) throws IOException {
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(filesBytes)) {
-            return ImageIO.read(bais);
-        }
-    }
+	@Test
+	public void testEncodeWithSrgbAndReadMetadata() throws IOException {
+		int width = 3;
+		int height = 2;
+		int[] image = { WHITE, BLACK, RED, GREEN, WHITE, BLUE };
+		BufferedImage bufferedImage = PngEncoderBufferedImageConverter.createFromIntArgb(image, width, height);
+		byte[] bytes = new PngEncoder().withBufferedImage(bufferedImage).withCompressionLevel(1)
+				.withSrgbRenderingIntent(PngEncoderSrgbRenderingIntent.PERCEPTUAL).toBytes();
 
-    public static IIOMetadata getImageMetaDataWithImageIO(byte[] filesBytes) throws IOException {
-        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(filesBytes); ImageInputStream input = ImageIO.createImageInputStream(inputStream)) {
-            Iterator<ImageReader> readers = ImageIO.getImageReaders(input);
-            ImageReader reader = readers.next();
+		IIOMetadata metadata = getImageMetaDataWithImageIO(bytes);
+		IIOMetadataNode root = (IIOMetadataNode) metadata.getAsTree(metadata.getNativeMetadataFormatName());
 
-            reader.setInput(input);
-            return reader.getImageMetadata(0);
-        }
-    }
+		assertThat(root.getElementsByTagName("sRGB").getLength(), is(1));
+		assertThat(root.getElementsByTagName("cHRM").getLength(), is(1));
+		assertThat(root.getElementsByTagName("gAMA").getLength(), is(1));
+	}
 
-    @ParameterizedTest()
-    @MethodSource("validCompressionLevels")
-    public void validCompressionLevel(int compressionLevel) {
-        assertDoesNotThrow(() -> new PngEncoder().withCompressionLevel(compressionLevel));
-    }
+	@Test
+	public void testEncodeWithPhysicalPixelDimensionsAndReadMetadata() throws IOException {
+		int dotsPerInch = 150;
+		byte[] bytes = new PngEncoder().withBufferedImage(ONE_PIXEL).withCompressionLevel(1)
+				.withPhysicalPixelDimensions(PngEncoderPhysicalPixelDimensions.dotsPerInch(dotsPerInch)).toBytes();
 
-    static IntStream validCompressionLevels() {
-        // Compression level value must be between -1 and 9 inclusive.
-        return IntStream.rangeClosed(-1, 9);
-    }
+		IIOMetadata metadata = getImageMetaDataWithImageIO(bytes);
+		IIOMetadataNode root = (IIOMetadataNode) metadata.getAsTree("javax_imageio_1.0");
+		float horizontalPixelSize = Float
+				.parseFloat(((Element) root.getElementsByTagName("HorizontalPixelSize").item(0)).getAttribute("value"));
+		float verticalPixelSize = Float
+				.parseFloat(((Element) root.getElementsByTagName("VerticalPixelSize").item(0)).getAttribute("value"));
 
-    @ParameterizedTest()
-    @ValueSource(ints = { -2, 10 })
-    public void invalidCompressionLevel(int compressionLevel) {
-        assertThrows(IllegalArgumentException.class, () -> new PngEncoder().withCompressionLevel(compressionLevel));
-    }
+		// Standard metadata contains the width/height of a pixel in millimeters
+		float mmPerInch = 25.4f;
+		assertThat(Math.round(mmPerInch / horizontalPixelSize), is(dotsPerInch));
+		assertThat(Math.round(mmPerInch / verticalPixelSize), is(dotsPerInch));
+	}
 
-    @Test
-    public void testEncodeWithoutImage() {
+	private static int[] readWithImageIOgetRGB(byte[] fileBytes) throws IOException {
+		BufferedImage bufferedImage = readWithImageIO(fileBytes);
+
+		return toIntArgb(bufferedImage);
+	}
+
+	private static int[] toIntArgb(BufferedImage bufferedImage) {
+		int width = bufferedImage.getWidth();
+		int height = bufferedImage.getHeight();
+		int[] argbImage = new int[width * height];
+
+		for (int y = 0; y < height; y++) {
+			for (int x = 0; x < width; x++) {
+				argbImage[y * width + x] = bufferedImage.getRGB(x, y);
+			}
+		}
+
+		return argbImage;
+	}
+
+	public static BufferedImage readWithImageIO(byte[] filesBytes) throws IOException {
+		try (ByteArrayInputStream bais = new ByteArrayInputStream(filesBytes)) {
+			return ImageIO.read(bais);
+		}
+	}
+
+	public static IIOMetadata getImageMetaDataWithImageIO(byte[] filesBytes) throws IOException {
+		try (ByteArrayInputStream inputStream = new ByteArrayInputStream(filesBytes);
+				ImageInputStream input = ImageIO.createImageInputStream(inputStream)) {
+			Iterator<ImageReader> readers = ImageIO.getImageReaders(input);
+			ImageReader reader = readers.next();
+
+			reader.setInput(input);
+			return reader.getImageMetadata(0);
+		}
+	}
+
+	@ParameterizedTest()
+	@MethodSource("validCompressionLevels")
+	public void validCompressionLevel(int compressionLevel) {
+		assertDoesNotThrow(() -> new PngEncoder().withCompressionLevel(compressionLevel));
+	}
+
+	static IntStream validCompressionLevels() {
+		// Compression level value must be between -1 and 9 inclusive.
+		return IntStream.rangeClosed(-1, 9);
+	}
+
+	@ParameterizedTest()
+	@ValueSource(ints = { -2, 10 })
+	public void invalidCompressionLevel(int compressionLevel) {
+		assertThrows(IllegalArgumentException.class, () -> new PngEncoder().withCompressionLevel(compressionLevel));
+	}
+
+	@Test
+	public void testEncodeWithoutImage() {
         // Document the fact that, at the moment, attempting to encode without providing an
-        // image throws NullPointException.
-        PngEncoder emptyEncoder = new PngEncoder();
-        assertThrows(NullPointerException.class, () -> emptyEncoder.toBytes());
+		// image throws NullPointException.
+		PngEncoder emptyEncoder = new PngEncoder();
+		assertThrows(NullPointerException.class, () -> emptyEncoder.toBytes());
 
-        PngEncoder encoderWithoutImage = new PngEncoder()
-                .withCompressionLevel(9)
-                .withMultiThreadedCompressionEnabled(true);
-        assertThrows(NullPointerException.class, () -> encoderWithoutImage.toBytes());
-    }
+		PngEncoder encoderWithoutImage = new PngEncoder().withCompressionLevel(9)
+				.withMultiThreadedCompressionEnabled(true);
+		assertThrows(NullPointerException.class, () -> encoderWithoutImage.toBytes());
+	}
 }

--- a/src/test/java/com/pngencoder/PngEncoderTestUtil.java
+++ b/src/test/java/com/pngencoder/PngEncoderTestUtil.java
@@ -14,7 +14,7 @@ class PngEncoderTestUtil {
     private static final OutputStream NULL_OUTPUT_STREAM = new NullOutputStream();
 
     private static final Random RANDOM = new Random();
-    private static final int DEFAULT_SIDE = 128;
+    private static final int DEFAULT_SIDE = 256;
 
     static BufferedImage createTestImage(PngEncoderBufferedImageType type) {
         return createTestImage(type, DEFAULT_SIDE);

--- a/src/test/java/com/pngencoder/SubimageEncodingTest.java
+++ b/src/test/java/com/pngencoder/SubimageEncodingTest.java
@@ -1,0 +1,123 @@
+package com.pngencoder;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.color.ColorSpace;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.ComponentColorModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.Raster;
+import java.awt.image.WritableRaster;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Hashtable;
+import java.util.Objects;
+import javax.imageio.ImageIO;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SubimageEncodingTest {
+    @Test
+    public void testSubimageEncoding() throws IOException {
+        PngEncoderBufferedImageType[] typesToTest = new PngEncoderBufferedImageType[]{
+                PngEncoderBufferedImageType.TYPE_BYTE_GRAY, PngEncoderBufferedImageType.TYPE_INT_RGB,
+                PngEncoderBufferedImageType.TYPE_INT_ARGB, PngEncoderBufferedImageType.TYPE_INT_BGR,
+                PngEncoderBufferedImageType.TYPE_3BYTE_BGR, PngEncoderBufferedImageType.TYPE_4BYTE_ABGR,
+                PngEncoderBufferedImageType.TYPE_USHORT_GRAY
+        };
+
+        for (PngEncoderBufferedImageType type : typesToTest) {
+            final BufferedImage bufferedImage = PngEncoderTestUtil.createTestImage(type);
+            testImageEncoders(type, bufferedImage);
+        }
+    }
+
+    private void testImageEncoders(PngEncoderBufferedImageType type, BufferedImage bufferedImage) throws IOException {
+        PngEncoder plainCompressor = new PngEncoder().withPredictorEncoding(false).withCompressionLevel(0).withMultiThreadedCompressionEnabled(false);
+        PngEncoder predictorCompressor = plainCompressor.withPredictorEncoding(true);
+        PngEncoder multithreadCompressor = plainCompressor.withMultiThreadedCompressionEnabled(true);
+        PngEncoder multithreadPredictorCompressor = plainCompressor.withMultiThreadedCompressionEnabled(true).withPredictorEncoding(true);
+        for (PngEncoder encoder : new PngEncoder[]{
+                plainCompressor,
+                predictorCompressor,
+                multithreadCompressor,
+                multithreadPredictorCompressor
+        }) {
+            validateImage(type, bufferedImage, encoder);
+            validateImage(type, bufferedImage.getSubimage(10, 10, 50, 50), encoder);
+        }
+    }
+
+    @Test
+    public void testUShortCustom() throws IOException {
+        final BufferedImage sourceImage = PngEncoderTestUtil.createTestImage(PngEncoderBufferedImageType.TYPE_4BYTE_ABGR);
+        BufferedImage imgRGBA = CustomDataBuffers.create16BitRGBA(sourceImage.getWidth(), sourceImage.getHeight());
+        Graphics2D graphics = imgRGBA.createGraphics();
+        graphics.drawImage(sourceImage, 0, 0, null);
+        graphics.dispose();
+        testImageEncoders(PngEncoderBufferedImageType.TYPE_CUSTOM, imgRGBA);
+    }
+
+    @Test
+    public void testIntCustom() throws IOException {
+        final BufferedImage sourceImage = ImageIO
+                .read(Objects.requireNonNull(PngEncoderTest.class.getResourceAsStream("/png-encoder-logo.png")));
+        BufferedImage imgRGBA = CustomDataBuffers.createInt8BitRGBA(sourceImage.getWidth(), sourceImage.getHeight());
+        Graphics2D graphics = imgRGBA.createGraphics();
+        graphics.drawImage(sourceImage, 0, 0, null);
+        graphics.dispose();
+        testImageEncoders(PngEncoderBufferedImageType.TYPE_CUSTOM, imgRGBA);
+    }
+
+    @Test
+    public void testUShort() throws IOException {
+        final BufferedImage sourceImage = PngEncoderTestUtil.createTestImage(PngEncoderBufferedImageType.TYPE_4BYTE_ABGR);
+        ColorSpace targetCS = ColorModel.getRGBdefault().getColorSpace();
+        int dataBufferType = DataBuffer.TYPE_USHORT;
+        final ColorModel colorModel = new ComponentColorModel(targetCS, true, false,
+                ColorModel.TRANSLUCENT, dataBufferType);
+        WritableRaster targetRaster = Raster.createInterleavedRaster(dataBufferType, sourceImage.getWidth(), sourceImage.getHeight(),
+                targetCS.getNumComponents() + 1, new Point(0, 0));
+
+        BufferedImage imgRGBA = new BufferedImage(colorModel, targetRaster, false, new Hashtable<>());
+        Graphics2D graphics = imgRGBA.createGraphics();
+        graphics.drawImage(sourceImage, 0, 0, null);
+        graphics.dispose();
+        testImageEncoders(PngEncoderBufferedImageType.TYPE_CUSTOM, imgRGBA);
+    }
+
+    @Test
+    public void testByteCustom() throws IOException {
+        final BufferedImage sourceImage = PngEncoderTestUtil.createTestImage(PngEncoderBufferedImageType.TYPE_4BYTE_ABGR);
+        BufferedImage imgRGBA = CustomDataBuffers.create8BitRGBA(sourceImage.getWidth(), sourceImage.getHeight(), sourceImage.getColorModel());
+        Graphics2D graphics = imgRGBA.createGraphics();
+        graphics.drawImage(sourceImage, 0, 0, null);
+        graphics.dispose();
+        testImageEncoders(PngEncoderBufferedImageType.TYPE_CUSTOM, imgRGBA);
+    }
+
+    private void validateImage(PngEncoderBufferedImageType type, BufferedImage image, PngEncoder encoder) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ImageIO.write(image, "PNG", outputStream);
+        byte[] imgData2 = encoder.withBufferedImage(image).toBytes();
+        BufferedImage img1 = ImageIO.read(new ByteArrayInputStream(outputStream.toByteArray()));
+        BufferedImage img2 = ImageIO.read(new ByteArrayInputStream(imgData2));
+        assertEquals(img1.getWidth(), img2.getWidth());
+        assertEquals(img2.getHeight(), img2.getHeight());
+        for (int y = 0; y < img1.getHeight(); y++) {
+            for (int x = 0; x < img1.getWidth(); x++) {
+                long rgbSource = image.getRGB(x, y) & 0xFFFFFFFFL;
+                long rgb1 = img1.getRGB(x, y) & 0xFFFFFFFFL;
+                long rgb2 = img2.getRGB(x, y) & 0xFFFFFFFFL;
+                assertEquals(rgbSource, rgb1, "Source compare failure with type " + type + " "
+                        + Long.toString(rgbSource, 16) + " != " + Long.toString(rgb1, 16));
+                assertEquals(rgb1, rgb2, "Compare failure with type " + type + " " + Long.toString(rgb1, 16) + " != "
+                        + Long.toString(rgb2, 16));
+            }
+        }
+    }
+}


### PR DESCRIPTION
I tried to regroup the changes into sensible commits. If you wish me to split up the changes in a different way, just say so.

This PR does those things:
- Adds a predictor encoder, which decreases file size but at the same time of course increases ZLib compression time, as ZLib has more stuff to save space but also has to do it.
- Fix #9 by supporting 16 bit images correctly
- Correctly handle sub-images
- Support non sRGB color spaces by embedding ICC color profiles.
- Small performance improvement when encoding the image without predictor (by streaming the image rows).

The objectplanet PNG encoder still compresses a little bit better, but this is now good enough for my use cases. You can always get smaller images by using pngcrush, ImageOptim and so on. But they also take a lot more time to process the images.

Please also make performance tests on your platforms, as I only tested the performance on M1 Max chips. The performance should be improved also a little bit on x64 - but I did not measure it.

After #14, #15, #16 and #17 are merged I can rebase this PR if you wish.