### PR TITLE
Add benchmark for multiple threads. ImageIO gains more :(

### DIFF
--- a/src/test/java/com/pngencoder/PngEncoderBenchmarkPngEncoderVsImageIO.java
+++ b/src/test/java/com/pngencoder/PngEncoderBenchmarkPngEncoderVsImageIO.java
@@ -30,23 +30,32 @@ import java.util.concurrent.TimeUnit;
  * 0.159 / 0.029 = 5.5 times faster
  */
 public class PngEncoderBenchmarkPngEncoderVsImageIO {
-    private static final Options OPTIONS = new OptionsBuilder()
-            .include(PngEncoderBenchmarkPngEncoderVsImageIO.class.getSimpleName() + ".*")
-            .shouldFailOnError(true)
-            .mode(Mode.Throughput)
-            .timeUnit(TimeUnit.SECONDS)
-            .threads(1)
-            .forks(1)
-            .warmupIterations(1)
-            .measurementIterations(1)
-            .warmupTime(TimeValue.seconds(2))
-            .measurementTime(TimeValue.seconds(5))
-            .build();
+
+    private static Options options(int threads) {
+        return new OptionsBuilder()
+                .include(PngEncoderBenchmarkPngEncoderVsImageIO.class.getSimpleName() + ".*")
+                .shouldFailOnError(true)
+                .mode(Mode.Throughput)
+                .timeUnit(TimeUnit.SECONDS)
+                .threads(threads)
+                .forks(1)
+                .warmupIterations(1)
+                .measurementIterations(1)
+                .warmupTime(TimeValue.seconds(2))
+                .measurementTime(TimeValue.seconds(5))
+                .build();
+    }
 
     @Disabled("run manually")
     @Test
-    public void runBenchmark() throws Exception {
-        new Runner(OPTIONS).run();
+    public void runBenchmarkOneThread() throws Exception {
+        new Runner(options(1)).run();
+    }
+
+    @Disabled("run manually")
+    @Test
+    public void runBenchmarkEightThreads() throws Exception {
+        new Runner(options(8)).run();
     }
 
     @State(Scope.Benchmark)


### PR DESCRIPTION

threads: 1
```
Benchmark                                                           Mode  Cnt    Score   Error  Units
PngEncoderBenchmarkPngEncoderVsImageIO.logo2121x350ImageIO         thrpt        33.649          ops/s
PngEncoderBenchmarkPngEncoderVsImageIO.logo2121x350PngEncoder      thrpt       169.037          ops/s
PngEncoderBenchmarkPngEncoderVsImageIO.looklet4900x6000ImageIO     thrpt         0.342          ops/s
PngEncoderBenchmarkPngEncoderVsImageIO.looklet4900x6000PngEncoder  thrpt         0.160          ops/s
PngEncoderBenchmarkPngEncoderVsImageIO.random1024x1024ImageIO      thrpt         5.023          ops/s
PngEncoderBenchmarkPngEncoderVsImageIO.random1024x1024PngEncoder   thrpt        36.494          ops/s
```

threads: 8
```
Benchmark                                                           Mode  Cnt    Score   Error  Units
PngEncoderBenchmarkPngEncoderVsImageIO.logo2121x350ImageIO         thrpt       100.600          ops/s
PngEncoderBenchmarkPngEncoderVsImageIO.logo2121x350PngEncoder      thrpt       205.676          ops/s
PngEncoderBenchmarkPngEncoderVsImageIO.looklet4900x6000ImageIO     thrpt         1.667          ops/s
PngEncoderBenchmarkPngEncoderVsImageIO.looklet4900x6000PngEncoder  thrpt         0.180          ops/s
PngEncoderBenchmarkPngEncoderVsImageIO.random1024x1024ImageIO      thrpt        18.403          ops/s
PngEncoderBenchmarkPngEncoderVsImageIO.random1024x1024PngEncoder   thrpt        35.249          ops/s
```
