### PR TITLE
Indexed encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 <img src="https://img.shields.io/maven-central/v/com.pngencoder/pngencoder"> <img src="https://img.shields.io/travis/pngencoder/pngencoder/develop"> <img src="https://img.shields.io/codecov/c/github/pngencoder/pngencoder/develop?token=305f39ec177948b3bde322c021debcdf">
 
 - About 5 times faster than ImageIO (on a computer with 8 logical cores)
+- Optional with better compression than ImageIO at the cost of speed by using predictor encoding.
+- Support for 8-bit and 16-bit RGB, ARGB, grayscale and indexed images.
+- ICC color profiles are exported when needed
 - Easy to use interface
 - [Semantic Versioning](http://semver.org/)
 - [MIT License](LICENSE)
@@ -46,8 +49,19 @@ public class Examples {
                 .toBytes();
     }
 
-    public static byte[] encodeWithBestCompression(BufferedImage bufferedImage) {
-        // Compression level 9 is the default and you actually need not set it.
+    public static byte[] encodeWithBestPredictorCompression(BufferedImage bufferedImage) {
+        // This produces image files way smaller than what ImageIO does. But
+        // it takes also way more time. Predictor encoding is off by default as it
+        // causes a performance hit.
+        return new PngEncoder()
+                .withBufferedImage(bufferedImage)
+                .withPredictorEncoding(true)
+                .withCompressionLevel(9)
+                .toBytes();
+    }
+
+    public static byte[] encodeWithBestCompressionWithoutPredictor(BufferedImage bufferedImage) {
+        // Compression level 9 is the default, and you actually need not set it.
         // It produces images with a size comparable to ImageIO.
         return new PngEncoder()
                 .withBufferedImage(bufferedImage)
@@ -64,8 +78,21 @@ public class Examples {
                 .toBytes();
     }
 
+    public static byte[] encodeWithBestCompressionTryIndexedEncoding(BufferedImage bufferedImage) {
+        // If there are likely no more than 256 colors used in the image (including color+alpha combinations),
+        // then you can try the indexed encoding. If it does not work, as there are more than 256 colors, it 
+        // will silently fall back to normal encoding. This setting will give you the best possible compression,
+        // but may also take the most time. 
+        return new PngEncoder()
+                .withBufferedImage(bufferedImage)
+                .withCompressionLevel(9)
+                .withTryIndexedEncoding(true)
+                .withPredictorEncoding(true)
+                .toBytes();
+    }
+
     public static CompletableFuture<Void> encodeToFileInOtherThread(BufferedImage bufferedImage, File file) {
-        // Perhaps all of the work can be done async to let the main thread continue?
+        // Perhaps all the work can be done async to let the main thread continue?
         // More of a general performance tip that's not limited to this PngEncoder library.
         return CompletableFuture.runAsync(() -> new PngEncoder()
                 .withBufferedImage(bufferedImage)
@@ -114,22 +141,23 @@ looklet4900x6000 | 0.159 | 0.029 | 5.5
 
 Run yourself using [PngEncoderBenchmarkPngEncoderVsImageIO.java](src/test/java/com/pngencoder/PngEncoderBenchmarkPngEncoderVsImageIO.java)
 
-Note that these numbers are for the default compression level 9 which produces images of about the same size as ImageIO. By lowering the compression level we can speed up encoding further. See the table below.
+Note that these numbers are for the default compression level 9 which produces images of about the same size as ImageIO. By lowering the compression level we can speed up encoding further. See the table below. 
+All this is without the predictor encoding.
 
 ## Compression Speed vs Size
 
-Compression Level | Speed | Size | Speed / Size
---- | --- | --- | ---
-9 (default) | 1.00 | 1.00 | 1.00
-8 | 1.10 | 1.14 | 0.97
-7 | 1.36 | 1.24 | 1.10
-6 | 1.40 | 1.23 | 1.14
-5 | 1.46 | 1.29 | 1.13
-4 | 1.49 | 1.30 | 1.15
-3 | 2.33 | 2.30 | 1.02
-2 | 2.31 | 2.42 | 0.96
-1 | 2.31 | 2.50 | 0.92
-0 | 3.11 | 206.80 | 0.02
+| Compression Level | Speed | Size   | Speed / Size |
+|-------------------|-------|--------|--------------|
+| 9 (default)       | 1.00  | 1.00   | 1.00         |
+| 8                 | 1.10  | 1.14   | 0.97         |
+| 7                 | 1.36  | 1.24   | 1.10         |
+| 6                 | 1.40  | 1.23   | 1.14         |
+| 5                 | 1.46  | 1.29   | 1.13         |
+| 4                 | 1.49  | 1.30   | 1.15         |
+| 3                 | 2.33  | 2.30   | 1.02         |
+| 2                 | 2.31  | 2.42   | 0.96         |
+| 1                 | 2.31  | 2.50   | 0.92         |
+| 0                 | 3.11  | 206.80 | 0.02         |
 
 Run yourself using [PngEncoderBenchmarkCompressionSpeedVsSize.java](src/test/java/com/pngencoder/PngEncoderBenchmarkCompressionSpeedVsSize.java)
 
@@ -144,11 +172,9 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md)
 ## Noteworthy Caveats
 This library achieves the speedup mainly using multithreading. The performance tests above were run on a computer with 8 logical cores. So if you for example use a single core computer (perhaps in the cloud) the speedup will not be significant.
 
-The file size is about 2% larger than images encoded by ImageIO. This small overhead is due to the multi-threaded compression.
+When using multithreading without predictor encoding the file size is about 2% larger than images encoded by ImageIO. This small overhead is due to the multithreaded compression.
 
-This library will output either a truecolor ARGB or RGB file. It does not support grayscale and indexed PNG file output.
-
-Support for metadata is currently close to zero. If you need comments in your PNG file, or advanced support for color profiles this library currently does not support that. If you just are interested in a simple SRGB profile there is an experimental method for it.
+Support for metadata is currently close to zero. If you need comments in your PNG file this library does not support that at the moment.
 
 ## Contributing
 When contributing please respect the style guide in the [CONTRIBUTING.md](./CONTRIBUTING.md). If you use IntellJ IDEA you can import the  [looklet_intellij_code_style.xml](./looklet_intellij_code_style.xml)

--- a/src/main/java/com/pngencoder/PngEncoder.java
+++ b/src/main/java/com/pngencoder/PngEncoder.java
@@ -77,7 +77,7 @@ public class PngEncoder {
     }
 
     /**
-     * Try to encode the image with indexed encoding. This only works if the image is RGB and uses not more then
+     * Try to encode the image with indexed encoding. This only works if the image is RGB and uses not more than
      * 256 colors.
      *
      * @param tryIndexedEncoding true if indexed encoding should be tried.

--- a/src/main/java/com/pngencoder/PngEncoderIndexed.java
+++ b/src/main/java/com/pngencoder/PngEncoderIndexed.java
@@ -120,6 +120,7 @@ public class PngEncoderIndexed {
 			result.transparencyTable = table.makeTransparencyTable();
 		}
         metaInfo.colorSpaceType = ColorSpaceType.Indexed;
+        metaInfo.rowByteSize = indexedRow.length;
         return result;
     }
 

--- a/src/main/java/com/pngencoder/PngEncoderIndexed.java
+++ b/src/main/java/com/pngencoder/PngEncoderIndexed.java
@@ -1,0 +1,177 @@
+package com.pngencoder;
+
+import com.pngencoder.PngEncoderScanlineUtil.AbstractPNGLineConsumer;
+import com.pngencoder.PngEncoderScanlineUtil.EncodingMetaInfo;
+import com.pngencoder.PngEncoderScanlineUtil.EncodingMetaInfo.ColorSpaceType;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class PngEncoderIndexed {
+    static class IndexedEncoderResult {
+        byte[] colorTable;
+        byte[] transparencyTable;
+        byte[] rawIDAT;
+    }
+
+    /**
+     * Encode the image as indexed image. This can fail if the image has more than 256 colors. But we only know this if
+     * we try to encode it. In case this image has more than 256 colors null is returned and everything written
+     * into out has to disposed.
+     *
+     * @param image    the Image to encode
+     * @param metaInfo the metaInfos of the image
+     * @return null if this image can not be encoded as indexed image or the additional chunk data needed for the indexed image.
+     * @throws IOException propagated IO Exception. Should not occur.
+     */
+    static IndexedEncoderResult encodeImage(BufferedImage image, EncodingMetaInfo metaInfo) throws IOException {
+        /*
+         * We only can encode 8 bit rgb image data here.
+         */
+		if (metaInfo.bitsPerChannel != 8 || metaInfo.channels == 1) {
+			return null;
+		}
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream(image.getHeight() * image.getWidth());
+
+        IndexedEncoderResult result = new IndexedEncoderResult();
+
+        // The first byte is 0; We don't try predictor encoding here. It's not worth the effort.
+        byte[] indexedRow = new byte[image.getWidth() + 1];
+
+        ColorTable table = new ColorTable();
+        try {
+            if (metaInfo.hasAlpha) {
+                PngEncoderScanlineUtil.stream(image, 0, image.getHeight(), new AbstractPNGLineConsumer() {
+                    boolean firstRow = true;
+
+                    @Override
+                    void consume(byte[] currRow, byte[] prevRow) throws IOException {
+                        if (firstRow) {
+                            int r = currRow[1] & 0xFF;
+                            int g = currRow[2] & 0xFF;
+                            int b = currRow[3] & 0xFF;
+                            int a = currRow[4] & 0xFF;
+                            int v = (a << 24) | (r << 16) | (g << 8) | b;
+							if (a == 0) {
+								v = 0;
+							}
+                            // initialise the first color slot
+                            table.findColorLookup(v);
+                            firstRow = false;
+                        }
+
+                        int readPtr = 1; // Skip predictor setting byte
+                        for (int x = 1; x < indexedRow.length; x++) {
+                            int r = currRow[readPtr++] & 0xFF;
+                            int g = currRow[readPtr++] & 0xFF;
+                            int b = currRow[readPtr++] & 0xFF;
+                            int a = currRow[readPtr++] & 0xFF;
+                            int v;
+							if (a == 0) {
+								v = 0;
+							} else {
+								v = (a << 24) | (r << 16) | (g << 8) | b;
+							}
+                            indexedRow[x] = table.findColor(v);
+                        }
+
+                        out.write(indexedRow);
+                    }
+                });
+            } else {
+                PngEncoderScanlineUtil.stream(image, 0, image.getHeight(), new AbstractPNGLineConsumer() {
+                    boolean firstRow = true;
+
+                    @Override
+                    void consume(byte[] currRow, byte[] prevRow) throws IOException {
+                        if (firstRow) {
+                            int r = currRow[1] & 0xFF;
+                            int g = currRow[2] & 0xFF;
+                            int b = currRow[3] & 0xFF;
+                            int v = 0xFF000000 | (r << 16) | (g << 8) | b;
+                            // initialise the first color slot
+                            table.findColorLookup(v);
+                            firstRow = false;
+                        }
+
+                        int readPtr = 1; // Skip predictor setting byte
+                        for (int x = 1; x < indexedRow.length; x++) {
+                            int r = currRow[readPtr++] & 0xFF;
+                            int g = currRow[readPtr++] & 0xFF;
+                            int b = currRow[readPtr++] & 0xFF;
+                            int v = 0xFF000000 | (r << 16) | (g << 8) | b;
+                            indexedRow[x] = table.findColor(v);
+                        }
+
+                        out.write(indexedRow);
+                    }
+                });
+            }
+        } catch (IndexOutOfBoundsException ignored) {
+            // We have more than 256 colors ...
+            return null;
+        }
+
+        result.rawIDAT = out.toByteArray();
+        result.colorTable = table.makeColorTable();
+		if (metaInfo.hasAlpha) {
+			result.transparencyTable = table.makeTransparencyTable();
+		}
+        metaInfo.colorSpaceType = ColorSpaceType.Indexed;
+        return result;
+    }
+
+    private static class ColorTable {
+        int[] colorTable = new int[256];
+        int usedColors = 0;
+        int lastColor;
+        int lastColorIndex = 0;
+
+        byte findColor(int color) {
+			if (lastColor == color) {
+				return (byte) lastColorIndex;
+			}
+            return (byte) findColorLookup(color);
+        }
+
+        private int findColorLookup(int color) {
+            for (int i = 0; i < usedColors; i++) {
+                if (colorTable[i] == color) {
+                    lastColor = color;
+                    lastColorIndex = i;
+                    return i;
+                }
+            }
+
+            int colorIndex = usedColors++;
+            colorTable[colorIndex] = color;
+            lastColor = color;
+            lastColorIndex = colorIndex;
+            return colorIndex;
+        }
+
+        public byte[] makeColorTable() {
+            byte[] res = new byte[3 * usedColors];
+            int dest = 0;
+            for (int i = 0; i < usedColors; i++) {
+                int color = colorTable[i];
+                res[dest++] = (byte) ((color & 0x00FF0000) >> 16);
+                res[dest++] = (byte) ((color & 0x0000FF00) >> 8);
+                res[dest++] = (byte) ((color & 0x000000FF));
+            }
+            return res;
+        }
+
+        public byte[] makeTransparencyTable() {
+            byte[] res = new byte[usedColors];
+            int dest = 0;
+            for (int i = 0; i < usedColors; i++) {
+                int color = colorTable[i];
+                res[dest++] = (byte) ((color & 0xFF000000) >> 24);
+            }
+            return res;
+        }
+    }
+}

--- a/src/main/java/com/pngencoder/PngEncoderLogic.java
+++ b/src/main/java/com/pngencoder/PngEncoderLogic.java
@@ -95,7 +95,7 @@ class PngEncoderLogic {
         countingOutputStream.write(FILE_BEGINNING);
 
         IndexedEncoderResult indexedEncoderResult = null;
-        if( bufferedImage.getType() == BufferedImage.TYPE_BYTE_INDEXED) {
+        if (bufferedImage.getType() == BufferedImage.TYPE_BYTE_INDEXED) {
             indexedEncoderResult = PngEncoderIndexed.encodeImageFromIndexed(bufferedImage, metaInfo);
         }
         else if (tryIndexedEncoding) {

--- a/src/main/java/com/pngencoder/PngEncoderLogic.java
+++ b/src/main/java/com/pngencoder/PngEncoderLogic.java
@@ -95,7 +95,10 @@ class PngEncoderLogic {
         countingOutputStream.write(FILE_BEGINNING);
 
         IndexedEncoderResult indexedEncoderResult = null;
-        if (tryIndexedEncoding) {
+        if( bufferedImage.getType() == BufferedImage.TYPE_BYTE_INDEXED) {
+            indexedEncoderResult = PngEncoderIndexed.encodeImageFromIndexed(bufferedImage, metaInfo);
+        }
+        else if (tryIndexedEncoding) {
             indexedEncoderResult = PngEncoderIndexed.encodeImage(bufferedImage, metaInfo);
         }
 

--- a/src/main/java/com/pngencoder/PngEncoderLogic.java
+++ b/src/main/java/com/pngencoder/PngEncoderLogic.java
@@ -97,8 +97,7 @@ class PngEncoderLogic {
         IndexedEncoderResult indexedEncoderResult = null;
         if (bufferedImage.getType() == BufferedImage.TYPE_BYTE_INDEXED) {
             indexedEncoderResult = PngEncoderIndexed.encodeImageFromIndexed(bufferedImage, metaInfo);
-        }
-        else if (tryIndexedEncoding) {
+        } else if (tryIndexedEncoding) {
             indexedEncoderResult = PngEncoderIndexed.encodeImage(bufferedImage, metaInfo);
         }
 

--- a/src/main/java/com/pngencoder/PngEncoderScanlineUtil.java
+++ b/src/main/java/com/pngencoder/PngEncoderScanlineUtil.java
@@ -95,7 +95,8 @@ class PngEncoderScanlineUtil {
 
         enum ColorSpaceType {
             Rgb,
-            Gray
+            Gray,
+            Indexed
         }
 
         /**

--- a/src/test/java/com/pngencoder/PngEncoderInputTypesTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderInputTypesTest.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import javax.imageio.ImageIO;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * LICENCE:
@@ -18,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * https://etc.usf.edu/clipart/36600/36667/thermos_36667_sm.gif
  * It is used as an example of an indexed input with no color depth.
  * The png encoder may (should?) convert it into a single grayscale channel.
- *
+ * <p>
  * https://etc.usf.edu/clipart/info/license
  */
 public class PngEncoderInputTypesTest {
@@ -33,6 +32,13 @@ public class PngEncoderInputTypesTest {
         BufferedImage unpacked = ImageIO.read(new ByteArrayInputStream(png));
 
         PngEncoderTestUtil.assertThatImageIsEqual(unpacked, bufferedImage);
+
+        BufferedImage subimage = bufferedImage.getSubimage(10, 10, 50, 50);
+        byte[] pngSubimage = new PngEncoder().withBufferedImage(subimage)
+                .toBytes();
+
+        BufferedImage unpackedSubimage = ImageIO.read(new ByteArrayInputStream(pngSubimage));
+        PngEncoderTestUtil.assertThatImageIsEqual(subimage, unpackedSubimage);
     }
 
     private BufferedImage getRealGifImage() {
@@ -49,6 +55,8 @@ public class PngEncoderInputTypesTest {
 
         assertEquals(channels, 1);
         assertEquals(metaInfo.channels, 3);
+        // By default, we will fall back to encode the image as sRGB image
+        assertEquals(metaInfo.colorSpaceType, PngEncoderScanlineUtil.EncodingMetaInfo.ColorSpaceType.Rgb);
     }
 
     @Test
@@ -91,7 +99,6 @@ public class PngEncoderInputTypesTest {
         BufferedImage unpacked = ImageIO.read(new ByteArrayInputStream(png));
 
         PngEncoderTestUtil.assertThatImageIsEqual(unpacked, bufferedImage);
-
     }
 
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderInputTypesTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderInputTypesTest.java
@@ -41,7 +41,7 @@ public class PngEncoderInputTypesTest {
         PngEncoderTestUtil.assertThatImageIsEqual(subimage, unpackedSubimage);
     }
 
-    private BufferedImage getRealGifImage() {
+    static BufferedImage getRealGifImage() {
         return PngEncoderTestUtil.readTestImageResource("thermos_36667_sm.gif");
     }
 

--- a/src/test/java/com/pngencoder/PngEncoderTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderTest.java
@@ -329,10 +329,9 @@ public class PngEncoderTest {
         int height = bufferedImage.getHeight();
         int[] argbImage = new int[width * height];
 
-        int writePtr = 0;
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
-                argbImage[writePtr++] = bufferedImage.getRGB(x, y);
+                argbImage[y * width + x] = bufferedImage.getRGB(x, y);
             }
         }
 

--- a/src/test/java/com/pngencoder/PngEncoderTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderTest.java
@@ -225,7 +225,23 @@ public class PngEncoderTest {
          * We can not compare the raw image rgba pixels, as the indexed encoder "normalizes" pixels with an alpha value of
          * zero to 0
          */
-        validateImage(PngEncoderBufferedImageType.TYPE_CUSTOM, bufferedImage, pngEncoder);
+        validateImage(bufferedImage, pngEncoder);
+    }
+
+    @Test
+    public void testDirectConvertedIndexEncoding() throws IOException {
+        final BufferedImage bufferedImage = PngEncoderInputTypesTest.getRealGifImage();
+
+        PngEncoder pngEncoder = new PngEncoder()
+                .withBufferedImage(bufferedImage)
+                .withCompressionLevel(1)
+                .withTryIndexedEncoding(true);
+
+        /*
+         * We can not compare the raw image rgba pixels, as the indexed encoder "normalizes" pixels with an alpha value of
+         * zero to 0
+         */
+        validateImage(bufferedImage, pngEncoder);
     }
 
     @Test

--- a/src/test/java/com/pngencoder/PngEncoderTest.java
+++ b/src/test/java/com/pngencoder/PngEncoderTest.java
@@ -378,11 +378,11 @@ public class PngEncoderTest {
         // Document the fact that, at the moment, attempting to encode without providing an
         // image throws NullPointException.
         PngEncoder emptyEncoder = new PngEncoder();
-        assertThrows(NullPointerException.class, () -> emptyEncoder.toBytes());
+        assertThrows(NullPointerException.class, emptyEncoder::toBytes);
 
         PngEncoder encoderWithoutImage = new PngEncoder()
                 .withCompressionLevel(9)
                 .withMultiThreadedCompressionEnabled(true);
-        assertThrows(NullPointerException.class, () -> encoderWithoutImage.toBytes());
+        assertThrows(NullPointerException.class, encoderWithoutImage::toBytes);
     }
 }

--- a/src/test/java/com/pngencoder/PngEncoderTestUtil.java
+++ b/src/test/java/com/pngencoder/PngEncoderTestUtil.java
@@ -94,8 +94,8 @@ class PngEncoderTestUtil {
         long alphaActual = actual & 0xFF000000L;
         long alphaExpected = actual & 0xFF000000L;
         if (alphaExpected == alphaActual && alphaExpected == 0) {
-            // The alpha is 0, so the pixel is not visible. So we don't care
-            // about the not visible rgb values. The indexed encoders flattens this
+            // The alpha is 0, so the pixel is not visible. We don't care
+            // about not visible rgb values. The indexed encoder flattens this
             // values to 0.
             return;
         }

--- a/src/test/java/com/pngencoder/PngEncoderTestUtil.java
+++ b/src/test/java/com/pngencoder/PngEncoderTestUtil.java
@@ -10,6 +10,8 @@ import java.io.UncheckedIOException;
 import java.util.Random;
 import javax.imageio.ImageIO;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 class PngEncoderTestUtil {
     private static final OutputStream NULL_OUTPUT_STREAM = new NullOutputStream();
 
@@ -73,6 +75,8 @@ class PngEncoderTestUtil {
     }
 
     public static void assertThatImageIsEqual(BufferedImage actual, BufferedImage expected) {
+        assertEquals(actual.getWidth(), expected.getWidth());
+        assertEquals(actual.getHeight(), expected.getHeight());
         for (int y = 0; y < expected.getHeight(); y++) {
             for (int x = 0; x < expected.getWidth(); x++) {
                 int expectedPixel = expected.getRGB(x, y);
@@ -87,7 +91,14 @@ class PngEncoderTestUtil {
             return;
         }
 
-        // TODO: If alpha is zero, it should be OK that the color values differ. This will be interesting to pre-multiplied alpha.
+        long alphaActual = actual & 0xFF000000L;
+        long alphaExpected = actual & 0xFF000000L;
+        if (alphaExpected == alphaActual && alphaExpected == 0) {
+            // The alpha is 0, so the pixel is not visible. So we don't care
+            // about the not visible rgb values. The indexed encoders flattens this
+            // values to 0.
+            return;
+        }
 
         String formattedActual = formatPixel(actual);
         String formattedExpected = formatPixel(expected);

--- a/src/test/java/com/pngencoder/SubimageEncodingTest.java
+++ b/src/test/java/com/pngencoder/SubimageEncodingTest.java
@@ -118,7 +118,7 @@ public class SubimageEncodingTest {
                 long rgb2 = img2.getRGB(x, y) & 0xFFFFFFFFL;
 
                 long a1 = (rgb1 & 0xFF000000) >> 24;
-                long a2 = (rgb1 & 0xFF000000) >> 24;
+                long a2 = (rgb2 & 0xFF000000) >> 24;
 
                 // We only compare the image rgb values if the alpha is not 0
                 if (a1 != 0 && a2 != 0) {

--- a/src/test/java/com/pngencoder/SubimageEncodingTest.java
+++ b/src/test/java/com/pngencoder/SubimageEncodingTest.java
@@ -18,8 +18,6 @@ import java.util.Hashtable;
 import java.util.Objects;
 import javax.imageio.ImageIO;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 public class SubimageEncodingTest {
     @Test
     public void testSubimageEncoding() throws IOException {
@@ -109,25 +107,8 @@ public class SubimageEncodingTest {
         byte[] imgData2 = encoder.withBufferedImage(image).toBytes();
         BufferedImage img1 = ImageIO.read(new ByteArrayInputStream(outputStream.toByteArray()));
         BufferedImage img2 = ImageIO.read(new ByteArrayInputStream(imgData2));
-        assertEquals(img1.getWidth(), img2.getWidth());
-        assertEquals(img2.getHeight(), img2.getHeight());
-        for (int y = 0; y < img1.getHeight(); y++) {
-            for (int x = 0; x < img1.getWidth(); x++) {
-                long rgbSource = image.getRGB(x, y) & 0xFFFFFFFFL;
-                long rgb1 = img1.getRGB(x, y) & 0xFFFFFFFFL;
-                long rgb2 = img2.getRGB(x, y) & 0xFFFFFFFFL;
 
-                long a1 = (rgb1 & 0xFF000000) >> 24;
-                long a2 = (rgb2 & 0xFF000000) >> 24;
-
-                // We only compare the image rgb values if the alpha is not 0
-                if (a1 != 0 || a2 != 0) {
-                    assertEquals(rgbSource, rgb1, "Source compare failure with type " + type + " "
-                            + Long.toString(rgbSource, 16) + " != " + Long.toString(rgb1, 16));
-                    assertEquals(rgb1, rgb2, "Compare failure with type " + type + " " + Long.toString(rgb1, 16) + " != "
-                            + Long.toString(rgb2, 16) + " at (" + x + "," + y + ")");
-                }
-            }
-        }
+        PngEncoderTestUtil.assertThatImageIsEqual(img1, image);
+        PngEncoderTestUtil.assertThatImageIsEqual(img2, image);
     }
 }

--- a/src/test/java/com/pngencoder/SubimageEncodingTest.java
+++ b/src/test/java/com/pngencoder/SubimageEncodingTest.java
@@ -30,11 +30,11 @@ public class SubimageEncodingTest {
 
         for (PngEncoderBufferedImageType type : typesToTest) {
             final BufferedImage bufferedImage = PngEncoderTestUtil.createTestImage(type);
-            testImageEncoders(type, bufferedImage);
+            testImageEncoders(bufferedImage);
         }
     }
 
-    private void testImageEncoders(PngEncoderBufferedImageType type, BufferedImage bufferedImage) throws IOException {
+    private void testImageEncoders(BufferedImage bufferedImage) throws IOException {
         PngEncoder plainCompressor = new PngEncoder().withPredictorEncoding(false).withCompressionLevel(0).withMultiThreadedCompressionEnabled(false);
         PngEncoder predictorCompressor = plainCompressor.withPredictorEncoding(true);
         PngEncoder multithreadCompressor = plainCompressor.withMultiThreadedCompressionEnabled(true);
@@ -48,8 +48,8 @@ public class SubimageEncodingTest {
                 multithreadPredictorCompressor,
                 indexedCompressor
         }) {
-            validateImage(type, bufferedImage, encoder);
-            validateImage(type, bufferedImage.getSubimage(10, 10, 50, 50), encoder);
+            validateImage(bufferedImage, encoder);
+            validateImage(bufferedImage.getSubimage(10, 10, 50, 50), encoder);
         }
     }
 
@@ -60,7 +60,7 @@ public class SubimageEncodingTest {
         Graphics2D graphics = imgRGBA.createGraphics();
         graphics.drawImage(sourceImage, 0, 0, null);
         graphics.dispose();
-        testImageEncoders(PngEncoderBufferedImageType.TYPE_CUSTOM, imgRGBA);
+        testImageEncoders(imgRGBA);
     }
 
     @Test
@@ -71,7 +71,7 @@ public class SubimageEncodingTest {
         Graphics2D graphics = imgRGBA.createGraphics();
         graphics.drawImage(sourceImage, 0, 0, null);
         graphics.dispose();
-        testImageEncoders(PngEncoderBufferedImageType.TYPE_CUSTOM, imgRGBA);
+        testImageEncoders(imgRGBA);
     }
 
     @Test
@@ -88,7 +88,7 @@ public class SubimageEncodingTest {
         Graphics2D graphics = imgRGBA.createGraphics();
         graphics.drawImage(sourceImage, 0, 0, null);
         graphics.dispose();
-        testImageEncoders(PngEncoderBufferedImageType.TYPE_CUSTOM, imgRGBA);
+        testImageEncoders(imgRGBA);
     }
 
     @Test
@@ -98,10 +98,10 @@ public class SubimageEncodingTest {
         Graphics2D graphics = imgRGBA.createGraphics();
         graphics.drawImage(sourceImage, 0, 0, null);
         graphics.dispose();
-        testImageEncoders(PngEncoderBufferedImageType.TYPE_CUSTOM, imgRGBA);
+        testImageEncoders(imgRGBA);
     }
 
-    static void validateImage(PngEncoderBufferedImageType type, BufferedImage image, PngEncoder encoder) throws IOException {
+    static void validateImage(BufferedImage image, PngEncoder encoder) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         ImageIO.write(image, "PNG", outputStream);
         byte[] imgData2 = encoder.withBufferedImage(image).toBytes();

--- a/src/test/java/com/pngencoder/SubimageEncodingTest.java
+++ b/src/test/java/com/pngencoder/SubimageEncodingTest.java
@@ -121,7 +121,7 @@ public class SubimageEncodingTest {
                 long a2 = (rgb2 & 0xFF000000) >> 24;
 
                 // We only compare the image rgb values if the alpha is not 0
-                if (a1 != 0 && a2 != 0) {
+                if (a1 != 0 || a2 != 0) {
                     assertEquals(rgbSource, rgb1, "Source compare failure with type " + type + " "
                             + Long.toString(rgbSource, 16) + " != " + Long.toString(rgb1, 16));
                     assertEquals(rgb1, rgb2, "Compare failure with type " + type + " " + Long.toString(rgb1, 16) + " != "


### PR DESCRIPTION
This implements an indexed encoder.

When activated the encoder *tries* to encode the image as an indexed image. But this only works if the are less than 256 colors. In case of an image with alpha, there should not be more than 256 color+alpha combinations.

And of course, the image must be in RGB color space.

While doing so I refactored the logic to create the deflater stream a bit to reduce code duplication.

Is this ok so, or do you want some part split into their own pull request?