### PR TITLE
feature/require-maven-version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,27 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.4.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.2.5</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.6.0</version>
                 <executions>


### PR DESCRIPTION
This makes checking for plugin updates a bit easier.

Before:
<img width="1392" alt="Screenshot 2023-10-17 at 13 24 11" src="https://github.com/pngencoder/pngencoder/assets/421009/460204ba-358c-4a70-b8c1-53fa409868fe">

After
<img width="1389" alt="Screenshot 2023-10-17 at 13 24 42" src="https://github.com/pngencoder/pngencoder/assets/421009/f4823fd6-2ba9-47fd-873c-8031a167e068">
