### PR TITLE
#70: end() is called at the end of single thread compression

### DIFF
--- a/src/main/java/com/pngencoder/PngEncoderLogic.java
+++ b/src/main/java/com/pngencoder/PngEncoderLogic.java
@@ -73,6 +73,7 @@ class PngEncoderLogic {
             action.encodeImageData(false, deflaterOutputStream);
             deflaterOutputStream.finish();
             deflaterOutputStream.flush();
+            deflater.end();
         } else {
             PngEncoderDeflaterOutputStream deflaterOutputStream = new PngEncoderDeflaterOutputStream(
                     outputStream, compressionLevel, segmentMaxLengthOriginal);


### PR DESCRIPTION
The explicit call of end() immediately releases native memory resources.